### PR TITLE
Fix not working keyboard padding on API below 30

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:windowSoftInputMode="adjustResize">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Thanks to @n3gbx, we discovered that keyboard padding is not working on devices with API below 30.

- Fixed keyboard padding

P. S. Fix was checked on emulators