### PR TITLE
EPMEDU-800: Fix status bar paddings

### DIFF
--- a/feature/more/src/main/java/com/epmedu/animeal/more/TabMoreScreen.kt
+++ b/feature/more/src/main/java/com/epmedu/animeal/more/TabMoreScreen.kt
@@ -3,7 +3,9 @@ package com.epmedu.animeal.more
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.epmedu.animeal.more.about.AboutScreen
 import com.epmedu.animeal.more.donate.DonateScreen
 import com.epmedu.animeal.more.help.HelpScreen
@@ -16,6 +18,7 @@ import com.epmedu.animeal.resources.R
 @Composable
 fun TabMoreScreen() {
     AnimatedScreenNavHost(
+        modifier = Modifier.statusBarsPadding(),
         startDestination = NavigationScreen.More.route.name,
         enterTransition = { slideIntoContainer(AnimatedContentScope.SlideDirection.Left) },
         exitTransition = { slideOutOfContainer(AnimatedContentScope.SlideDirection.Right) }

--- a/feature/more/src/main/java/com/epmedu/animeal/more/profile/ProfileScreenUI.kt
+++ b/feature/more/src/main/java/com/epmedu/animeal/more/profile/ProfileScreenUI.kt
@@ -2,7 +2,13 @@ package com.epmedu.animeal.more.profile
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -60,8 +66,7 @@ internal fun ProfileScreenUI(
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .imePadding()
-            .systemBarsPadding(),
+            .imePadding(),
         topBar = {
             ProfileTopBar(onBack = {
                 if (state.readonly) onBack()

--- a/feature/more/src/main/java/com/epmedu/animeal/more/root/MoreScreenUi.kt
+++ b/feature/more/src/main/java/com/epmedu/animeal/more/root/MoreScreenUi.kt
@@ -1,6 +1,9 @@
 package com.epmedu.animeal.more.root
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Scaffold
@@ -23,8 +26,7 @@ internal fun MoreScreenUi(
 ) {
     Scaffold(
         modifier = Modifier
-            .fillMaxSize()
-            .systemBarsPadding(),
+            .fillMaxSize(),
         topBar = {
             TopBar(title = stringResource(id = R.string.more))
         }

--- a/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/SignUpScreen.kt
+++ b/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/SignUpScreen.kt
@@ -1,6 +1,6 @@
 package com.epmedu.animeal.signup
 
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.epmedu.animeal.navigation.ScreenNavHost
@@ -13,7 +13,7 @@ import com.epmedu.animeal.signup.onboarding.presentation.OnboardingScreen
 @Composable
 fun SignUpScreen() {
     ScreenNavHost(
-        modifier = Modifier.systemBarsPadding(),
+        modifier = Modifier.statusBarsPadding(),
         startDestination = SignUpRoute.Onboarding.name
     ) {
         screen(SignUpRoute.Onboarding.name) { OnboardingScreen() }

--- a/feature/tabs/src/main/java/com/epmedu/animeal/tabs/presentation/HomeScreen.kt
+++ b/feature/tabs/src/main/java/com/epmedu/animeal/tabs/presentation/HomeScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -68,7 +68,7 @@ private fun Maps() {
         AnimealSwitch(
             modifier = Modifier
                 .align(alignment = Alignment.TopCenter)
-                .systemBarsPadding()
+                .statusBarsPadding()
                 .padding(top = 24.dp),
             onSelectTab = {}
         )


### PR DESCRIPTION
- Added status bar padding for TabsMoreScreen (NavHost)
- Removed redundant status bar paddings from MoreScreen and ProfileScreen
- Replaced system bar paddings with status bar paddings, since there is navigation bar padding in the root screen

[Video](https://user-images.githubusercontent.com/83027107/185977681-46fec3c1-1737-4c44-bb0f-5a5cc155fb36.mp4)