### PR TITLE
EPMEDU-890: Integrate Compose Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@
 
 #### - gradle-versions-plugin - checks the latest version of libraries
 `gradle dependencyUpdate`
+
+
+#### - Compose metrics
+`gradle assembleRelease -Panimeal.enableComposeCompilerReports=true`
+
+More info: https://chris.banes.dev/composable-metrics/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.epmedu.animeal.extension.propertyInt
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.konan.properties.loadProperties
 import org.jetbrains.kotlin.konan.properties.saveToFile
@@ -73,4 +74,16 @@ fun isNonStable(version: String): Boolean {
     val regex = "^[0-9,.v-]+(-r)?$".toRegex()
     val isStable = stableKeyword || regex.matches(version)
     return isStable.not()
+}
+
+subprojects {
+    tasks.withType<KotlinCompile>().configureEach {
+        kotlinOptions {
+            if (project.findProperty("animeal.enableComposeCompilerReports") == "true") {
+                freeCompilerArgs = freeCompilerArgs +
+                        "-P=plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir.absolutePath}/compose_metrics" +
+                        "-P=plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.buildDir.absolutePath}/compose_metrics"
+            }
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
Please read before: https://chris.banes.dev/composable-metrics/

Current problem which cause recomposition on Map screen

<img width="486" alt="image" src="https://user-images.githubusercontent.com/16294951/192117960-c15cb758-8e29-4370-ab03-f51d529cea60.png">

Possible solutions: https://medium.com/@takahirom/cautions-for-using-classes-of-other-modules-as-arguments-of-composable-functions-in-jetpack-compose-b26f1e1dfc9d

Preferable for us:
- Mark as `Stable` annotation (applied on PR)
- Create separate UI model

After changes
<img width="532" alt="image" src="https://user-images.githubusercontent.com/16294951/192118076-9ea2f3e9-db3a-4381-9f5a-33fc15dbb60e.png">



All boolean variables can be removed in https://github.com/AnimealProject/animeal_android/pull/69