### PR TITLE
[EPMEDU-1095]: BottomSheet hides BottomAppBar when slide manually

### DIFF
--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
@@ -36,7 +36,7 @@ internal fun HomeScreenUI(
 ) {
     val changeBottomBarVisibilityState = LocalBottomBarVisibilityController.current
 
-    LaunchedEffect(bottomSheetState.progress) {
+    LaunchedEffect(bottomSheetState.progress, bottomSheetState.currentValue) {
         val showBottomBar = if (bottomSheetState.isShowing) false else bottomSheetState.isHidden
 
         changeBottomBarVisibilityState(BottomBarVisibilityState.ofBoolean(showBottomBar))


### PR DESCRIPTION
Bottom sheet state value is updated after animation finishes so `LaunchedEffect` is not called to reappear bottom navigation bar.