### PR TITLE
EPMEDU-879 [Android] Add bottom sheet state change on map interaction

### DIFF
--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
@@ -93,7 +93,8 @@ internal fun HomeScreenUI(
             MapContent(
                 state = state,
                 onFeedingPointSelect = { onScreenEvent(FeedingPointSelected(it.id)) },
-                onGeolocationClick = { onScreenEvent(UserCurrentGeolocationRequest) }
+                onGeolocationClick = { onScreenEvent(UserCurrentGeolocationRequest) },
+                onMapInteraction = { if (!bottomSheetState.isHiding) scope.launch { bottomSheetState.show() } }
             )
         }
     }
@@ -105,12 +106,14 @@ internal fun HomeScreenUI(
 private fun MapContent(
     state: HomeState,
     onFeedingPointSelect: (point: FeedingPointUi) -> Unit,
-    onGeolocationClick: () -> Unit
+    onGeolocationClick: () -> Unit,
+    onMapInteraction: () -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         MapboxMap(
             state = state,
-            onFeedingPointClick = onFeedingPointSelect
+            onFeedingPointClick = onFeedingPointSelect,
+            onMapInteraction = onMapInteraction
         )
         AnimealSwitch(
             modifier = Modifier

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/MapboxMap.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/MapboxMap.kt
@@ -7,13 +7,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.epmedu.animeal.home.presentation.model.FeedingPointUi
-import com.epmedu.animeal.home.presentation.ui.map.*
+import com.epmedu.animeal.home.presentation.ui.map.MapBoxInitOptions
+import com.epmedu.animeal.home.presentation.ui.map.MapUiSettings
+import com.epmedu.animeal.home.presentation.ui.map.MarkerController
+import com.epmedu.animeal.home.presentation.ui.map.rememberMapInitOptions
+import com.epmedu.animeal.home.presentation.ui.map.rememberMapUiSettings
+import com.epmedu.animeal.home.presentation.ui.map.rememberMapViewWithLifecycle
+import com.epmedu.animeal.home.presentation.ui.map.setGesturesListener
+import com.epmedu.animeal.home.presentation.ui.map.setLocation
 import com.epmedu.animeal.home.presentation.viewmodel.HomeState
 
 @Composable
 fun MapboxMap(
     state: HomeState,
-    onFeedingPointClick: (point: FeedingPointUi) -> Unit
+    onFeedingPointClick: (point: FeedingPointUi) -> Unit,
+    onMapInteraction: () -> Unit
 ) {
     val mapView = rememberMapViewWithLifecycle(
         mapBoxInitOptions = rememberMapInitOptions(
@@ -37,6 +45,8 @@ fun MapboxMap(
             onFeedingPointClick = onFeedingPointClick
         )
     }
+
+    mapView.setGesturesListener(onMapInteraction = onMapInteraction)
 
     LaunchedEffect(key1 = state.feedingPoints) {
         markerController.drawMarkers(

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/MapView.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/MapView.kt
@@ -6,7 +6,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.epmedu.animeal.home.presentation.model.MapLocation
 import com.mapbox.geojson.Point
-import com.mapbox.maps.*
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapInitOptions
+import com.mapbox.maps.MapView
+import com.mapbox.maps.ResourceOptions
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.maps.plugin.scalebar.scalebar
@@ -54,3 +57,8 @@ fun MapView.setLocation(location: MapLocation) = getMapboxMap().setCamera(
         .center(Point.fromLngLat(location.longitude, location.latitude))
         .build()
 )
+
+fun MapView.setGesturesListener(onMapInteraction: () -> Unit) =
+    getMapboxMap().addOnCameraChangeListener {
+        onMapInteraction()
+    }


### PR DESCRIPTION
When the bottomsheet is full expanded and the user move around the map it should transition to half expanded (collapsed)

- Added mapBox onCameraChangeListener
- Added bottomsheet state change on map interaction

https://user-images.githubusercontent.com/11144164/204142451-6d88ac93-06e6-46f4-adcd-9893ecff31a5.mp4

