### PR TITLE
[EPMEDU-1173]: Align code confirmation logic with backend to allow multiple entry attempts

### DIFF
--- a/feature/signupflow/entercode/build.gradle.kts
+++ b/feature/signupflow/entercode/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation(projects.library.navigation)
     implementation(projects.library.resources)
 
+    implementation(libs.amplify.aws.auth.cognito)
+
     implementation(libs.androidx.datastore)
     implementation(libs.androidx.viewmodel)
 

--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/domain/ConfirmCodeUseCase.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/domain/ConfirmCodeUseCase.kt
@@ -1,5 +1,6 @@
 package com.epmedu.animeal.signup.entercode.domain
 
+import com.amplifyframework.auth.result.AuthSignInResult
 import com.epmedu.animeal.auth.AuthRequestHandler
 import com.epmedu.animeal.signup.entercode.data.EnterCodeRepository
 
@@ -11,7 +12,11 @@ class ConfirmCodeUseCase(private val repository: EnterCodeRepository) {
     ) {
         val requestHandler = object : AuthRequestHandler {
             override fun onSuccess(result: Any?) {
-                onSuccess()
+                val authResult = result as AuthSignInResult
+                when {
+                    authResult.isSignInComplete -> onSuccess()
+                    else -> onError(InvalidCodeError())
+                }
             }
 
             override fun onError(exception: Exception) {
@@ -22,3 +27,5 @@ class ConfirmCodeUseCase(private val repository: EnterCodeRepository) {
         repository.confirmCode(code, requestHandler)
     }
 }
+
+class InvalidCodeError : Exception()


### PR DESCRIPTION
Until today confirmation code could be validated only once.
If user entered wrong code, he must click resend button to receive a new code and try again.
But backend team has changed it, so we have to align with these changes.
Now user has 3 attempts to enter confirmation code.

https://user-images.githubusercontent.com/83027107/207840779-422ed077-4a82-4e18-abcc-6efec72840cc.mp4