### PR TITLE
[EPMEDU-1168]: Phone number is showing incorrectly in profile info

### DIFF
--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/data/EnterCodeRepository.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/data/EnterCodeRepository.kt
@@ -4,7 +4,7 @@ import com.epmedu.animeal.auth.AuthRequestHandler
 import kotlinx.coroutines.flow.Flow
 
 interface EnterCodeRepository {
-    val phoneNumber: Flow<String>
+    val phoneNumberWithPrefix: Flow<String>
 
     suspend fun sendCode(requestHandler: AuthRequestHandler)
 

--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/data/EnterCodeRepositoryImpl.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/data/EnterCodeRepositoryImpl.kt
@@ -5,6 +5,9 @@ import androidx.datastore.preferences.core.Preferences
 import com.epmedu.animeal.auth.AuthAPI
 import com.epmedu.animeal.auth.AuthRequestHandler
 import com.epmedu.animeal.common.constants.DataStorePreferencesKey.phoneNumberKey
+import com.epmedu.animeal.common.constants.DataStorePreferencesKey.phoneNumberPrefixKey
+import com.epmedu.animeal.common.constants.DefaultConstants.EMPTY_STRING
+import com.epmedu.animeal.common.constants.DefaultConstants.PHONE_NUMBER_PREFIX
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -15,13 +18,15 @@ internal class EnterCodeRepositoryImpl @Inject constructor(
     private val authAPI: AuthAPI,
 ) : EnterCodeRepository {
 
-    override val phoneNumber: Flow<String> = dataStore.data
+    override val phoneNumberWithPrefix: Flow<String> = dataStore.data
         .map { preferences ->
-            preferences[phoneNumberKey] ?: ""
+            val prefix = preferences[phoneNumberPrefixKey] ?: PHONE_NUMBER_PREFIX
+            val phoneNumber = preferences[phoneNumberKey] ?: EMPTY_STRING
+            prefix + phoneNumber
         }
 
     override suspend fun sendCode(requestHandler: AuthRequestHandler) {
-        authAPI.sendCode(phoneNumber.first(), requestHandler)
+        authAPI.sendCode(phoneNumberWithPrefix.first(), requestHandler)
     }
 
     override fun confirmCode(

--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/domain/GetPhoneNumberUseCase.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/domain/GetPhoneNumberUseCase.kt
@@ -5,6 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 class GetPhoneNumberUseCase(private val repository: EnterCodeRepository) {
     operator fun invoke(): Flow<String> {
-        return repository.phoneNumber
+        return repository.phoneNumberWithPrefix
     }
 }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/data/EnterPhoneRepository.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/data/EnterPhoneRepository.kt
@@ -4,7 +4,10 @@ import com.epmedu.animeal.auth.AuthRequestHandler
 
 interface EnterPhoneRepository {
 
-    suspend fun savePhoneNumber(phoneNumber: String)
+    suspend fun savePhoneNumberAndPrefix(
+        prefix: String,
+        phoneNumber: String
+    )
 
     fun signUp(
         phone: String,

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/data/EnterPhoneRepositoryImpl.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/data/EnterPhoneRepositoryImpl.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import com.epmedu.animeal.auth.AuthAPI
 import com.epmedu.animeal.auth.AuthRequestHandler
 import com.epmedu.animeal.common.constants.DataStorePreferencesKey.phoneNumberKey
+import com.epmedu.animeal.common.constants.DataStorePreferencesKey.phoneNumberPrefixKey
 import javax.inject.Inject
 
 internal class EnterPhoneRepositoryImpl @Inject constructor(
@@ -13,8 +14,12 @@ internal class EnterPhoneRepositoryImpl @Inject constructor(
     private val authAPI: AuthAPI,
 ) : EnterPhoneRepository {
 
-    override suspend fun savePhoneNumber(phoneNumber: String) {
+    override suspend fun savePhoneNumberAndPrefix(
+        prefix: String,
+        phoneNumber: String
+    ) {
         dataStore.edit { preferences ->
+            preferences[phoneNumberPrefixKey] = prefix
             preferences[phoneNumberKey] = phoneNumber
         }
     }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/di/EnterPhoneModule.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/di/EnterPhoneModule.kt
@@ -5,7 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.epmedu.animeal.auth.AuthAPI
 import com.epmedu.animeal.signup.enterphone.data.EnterPhoneRepository
 import com.epmedu.animeal.signup.enterphone.data.EnterPhoneRepositoryImpl
-import com.epmedu.animeal.signup.enterphone.domain.SavePhoneNumberUseCase
+import com.epmedu.animeal.signup.enterphone.domain.SavePhoneNumberAndPrefixUseCase
 import com.epmedu.animeal.signup.enterphone.domain.SignUpAndSignInUseCase
 import dagger.Module
 import dagger.Provides
@@ -34,5 +34,5 @@ internal object EnterPhoneModule {
     @Provides
     fun provideSavePhoneNumberUseCase(
         repository: EnterPhoneRepository
-    ) = SavePhoneNumberUseCase(repository)
+    ) = SavePhoneNumberAndPrefixUseCase(repository)
 }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/domain/SavePhoneNumberAndPrefixUseCase.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/domain/SavePhoneNumberAndPrefixUseCase.kt
@@ -4,8 +4,9 @@ import com.epmedu.animeal.signup.enterphone.data.EnterPhoneRepository
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.withContext
 
-class SavePhoneNumberUseCase(private val repository: EnterPhoneRepository) {
+class SavePhoneNumberAndPrefixUseCase(private val repository: EnterPhoneRepository) {
     suspend operator fun invoke(
+        prefix: String,
         phoneNumber: String,
         onSuccess: () -> Unit,
         onError: () -> Unit,
@@ -15,7 +16,7 @@ class SavePhoneNumberUseCase(private val repository: EnterPhoneRepository) {
                 onError()
             }
         ) {
-            repository.savePhoneNumber(phoneNumber)
+            repository.savePhoneNumberAndPrefix(prefix, phoneNumber)
             onSuccess()
         }
     }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreen.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreen.kt
@@ -10,6 +10,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.epmedu.animeal.common.route.SignUpRoute
 import com.epmedu.animeal.extensions.currentOrThrow
 import com.epmedu.animeal.navigation.navigator.LocalNavigator
+import com.epmedu.animeal.signup.enterphone.presentation.viewmodel.EnterPhoneEvent
 import com.epmedu.animeal.signup.enterphone.presentation.viewmodel.EnterPhoneViewModel
 
 @Composable
@@ -22,16 +23,13 @@ fun EnterPhoneScreen() {
     EnterPhoneScreenUi(
         state = state,
         focusRequester = focusRequester,
-        onNumberChange = { viewModel.updatePhoneNumber(it) },
-        onBack = navigator::popBackStack,
-        onNext = {
-            viewModel.savePhoneNumberAndSendCode()
-        }
+        onEvent = viewModel::handleEvents,
+        onBack = navigator::popBackStack
     )
 
     LaunchedEffect(Unit) {
         viewModel.events.collect {
-            if (it is EnterPhoneViewModel.Event.NavigateToEnterCode) {
+            if (it is EnterPhoneEvent.NavigateToEnterCode) {
                 navigator.navigate(SignUpRoute.EnterCode.name)
             }
         }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenEvent.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenEvent.kt
@@ -1,0 +1,6 @@
+package com.epmedu.animeal.signup.enterphone.presentation
+
+sealed interface EnterPhoneScreenEvent {
+    data class UpdatePhoneNumber(val phoneNumber: String) : EnterPhoneScreenEvent
+    object NextButtonClicked : EnterPhoneScreenEvent
+}

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenUi.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenUi.kt
@@ -15,15 +15,16 @@ import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.foundation.topbar.BackButton
 import com.epmedu.animeal.foundation.topbar.TopBar
 import com.epmedu.animeal.resources.R
+import com.epmedu.animeal.signup.enterphone.presentation.EnterPhoneScreenEvent.NextButtonClicked
+import com.epmedu.animeal.signup.enterphone.presentation.EnterPhoneScreenEvent.UpdatePhoneNumber
 import com.epmedu.animeal.signup.enterphone.presentation.viewmodel.EnterPhoneState
 
 @Composable
 internal fun EnterPhoneScreenUi(
     state: EnterPhoneState,
     focusRequester: FocusRequester,
-    onNumberChange: (String) -> Unit,
+    onEvent: (EnterPhoneScreenEvent) -> Unit,
     onBack: () -> Unit,
-    onNext: () -> Unit
 ) {
     Scaffold(
         modifier = Modifier
@@ -41,7 +42,7 @@ internal fun EnterPhoneScreenUi(
             AnimealShortButton(
                 text = stringResource(id = R.string.next),
                 enabled = state.isNextEnabled,
-                onClick = onNext
+                onClick = { onEvent(NextButtonClicked) }
             )
         }
     ) { padding ->
@@ -52,10 +53,11 @@ internal fun EnterPhoneScreenUi(
         ) {
             PhoneNumberInput(
                 value = state.phoneNumber,
+                prefix = state.prefix,
                 modifier = Modifier
                     .padding(top = 56.dp)
                     .focusRequester(focusRequester),
-                onValueChange = onNumberChange,
+                onValueChange = { onEvent(UpdatePhoneNumber(it)) },
                 error = if (state.isError) stringResource(id = R.string.enter_phone_error) else ""
             )
         }
@@ -69,9 +71,8 @@ private fun EnterPhoneScreenPreview() {
         EnterPhoneScreenUi(
             focusRequester = FocusRequester(),
             state = EnterPhoneState(),
-            onNumberChange = {},
-            onBack = {},
-            onNext = {}
+            onEvent = {},
+            onBack = {}
         )
     }
 }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/viewmodel/EnterPhoneEvent.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/viewmodel/EnterPhoneEvent.kt
@@ -1,0 +1,5 @@
+package com.epmedu.animeal.signup.enterphone.presentation.viewmodel
+
+sealed interface EnterPhoneEvent {
+    object NavigateToEnterCode : EnterPhoneEvent
+}

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/viewmodel/EnterPhoneState.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/viewmodel/EnterPhoneState.kt
@@ -1,7 +1,11 @@
 package com.epmedu.animeal.signup.enterphone.presentation.viewmodel
 
+import com.epmedu.animeal.common.constants.DefaultConstants.EMPTY_STRING
+import com.epmedu.animeal.common.constants.DefaultConstants.PHONE_NUMBER_PREFIX
+
 internal data class EnterPhoneState(
-    val phoneNumber: String = "",
+    val prefix: String = PHONE_NUMBER_PREFIX,
+    val phoneNumber: String = EMPTY_STRING,
     val isNextEnabled: Boolean = false,
     val isError: Boolean = false
 )

--- a/library/common/src/main/java/com/epmedu/animeal/common/constants/DataStorePreferencesKey.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/constants/DataStorePreferencesKey.kt
@@ -3,6 +3,7 @@ package com.epmedu.animeal.common.constants
 import androidx.datastore.preferences.core.stringPreferencesKey
 
 object DataStorePreferencesKey {
+    val phoneNumberPrefixKey = stringPreferencesKey("phone_number_prefix")
     val phoneNumberKey = stringPreferencesKey("phone_number")
     val nameKey = stringPreferencesKey("name")
     val surnameKey = stringPreferencesKey("surname")

--- a/library/common/src/main/java/com/epmedu/animeal/common/constants/DefaultConstants.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/constants/DefaultConstants.kt
@@ -1,5 +1,6 @@
 package com.epmedu.animeal.common.constants
 
-object Text {
+object DefaultConstants {
     const val EMPTY_STRING = ""
+    const val PHONE_NUMBER_PREFIX = "+995"
 }

--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/input/PhoneNumberInput.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/input/PhoneNumberInput.kt
@@ -23,14 +23,15 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.epmedu.animeal.foundation.common.validation.Constants.PHONE_NUMBER_LENGTH
 import com.epmedu.animeal.foundation.input.PhoneFormatTransformation.PHONE_NUMBER_FORMAT
-import com.epmedu.animeal.foundation.input.PhoneFormatTransformation.PHONE_NUMBER_PREFIX
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.resources.R
 
+@Suppress("LongParameterList")
 @Composable
 fun PhoneNumberInput(
     value: String,
+    prefix: String,
     modifier: Modifier = Modifier,
     onValueChange: (String) -> Unit = {},
     error: String = "",
@@ -61,7 +62,7 @@ fun PhoneNumberInput(
                     contentDescription = null
                 )
                 Text(
-                    text = PHONE_NUMBER_PREFIX,
+                    text = prefix,
                     color = Color.Black,
                     fontWeight = FontWeight.ExtraLight
                 )
@@ -74,7 +75,6 @@ fun PhoneNumberInput(
 }
 
 object PhoneFormatTransformation : VisualTransformation {
-    const val PHONE_NUMBER_PREFIX = "+995"
     internal const val PHONE_NUMBER_FORMAT = "xxx xx-xx-xx"
 
     override fun filter(text: AnnotatedString): TransformedText {
@@ -126,16 +126,19 @@ private fun PhoneNumberInputPreview() {
     AnimealTheme {
         Column {
             PhoneNumberInput(
-                value = ""
+                value = "",
+                prefix = "+995"
             )
             Divider()
             PhoneNumberInput(
                 value = "123456789",
+                prefix = "+995",
                 isEnabled = false
             )
             Divider()
             PhoneNumberInput(
                 value = "1234567",
+                prefix = "+995",
                 isEnabled = false,
                 error = "Phone Number is too short"
             )

--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/data/model/Profile.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/data/model/Profile.kt
@@ -1,9 +1,13 @@
 package com.epmedu.animeal.profile.data.model
 
+import com.epmedu.animeal.common.constants.DefaultConstants.EMPTY_STRING
+import com.epmedu.animeal.common.constants.DefaultConstants.PHONE_NUMBER_PREFIX
+
 data class Profile(
-    val name: String = "",
-    val surname: String = "",
-    val birthDate: String = "",
-    val phoneNumber: String = "",
-    val email: String = ""
+    val name: String = EMPTY_STRING,
+    val surname: String = EMPTY_STRING,
+    val birthDate: String = EMPTY_STRING,
+    val phoneNumberPrefix: String = PHONE_NUMBER_PREFIX,
+    val phoneNumber: String = EMPTY_STRING,
+    val email: String = EMPTY_STRING
 )

--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/data/repository/ProfileRepositoryImpl.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/data/repository/ProfileRepositoryImpl.kt
@@ -9,8 +9,10 @@ import com.epmedu.animeal.common.constants.DataStorePreferencesKey.birthDateKey
 import com.epmedu.animeal.common.constants.DataStorePreferencesKey.emailKey
 import com.epmedu.animeal.common.constants.DataStorePreferencesKey.nameKey
 import com.epmedu.animeal.common.constants.DataStorePreferencesKey.phoneNumberKey
+import com.epmedu.animeal.common.constants.DataStorePreferencesKey.phoneNumberPrefixKey
 import com.epmedu.animeal.common.constants.DataStorePreferencesKey.surnameKey
-import com.epmedu.animeal.common.constants.Text.EMPTY_STRING
+import com.epmedu.animeal.common.constants.DefaultConstants.EMPTY_STRING
+import com.epmedu.animeal.common.constants.DefaultConstants.PHONE_NUMBER_PREFIX
 import com.epmedu.animeal.profile.data.model.Profile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -28,6 +30,7 @@ internal class ProfileRepositoryImpl @Inject constructor(
             Profile(
                 name = preferences[nameKey] ?: EMPTY_STRING,
                 surname = preferences[surnameKey] ?: EMPTY_STRING,
+                phoneNumberPrefix = preferences[phoneNumberPrefixKey] ?: PHONE_NUMBER_PREFIX,
                 phoneNumber = preferences[phoneNumberKey] ?: EMPTY_STRING,
                 email = preferences[emailKey] ?: EMPTY_STRING,
                 birthDate = preferences[birthDateKey] ?: EMPTY_STRING,

--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/ProfileInputForm.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/ProfileInputForm.kt
@@ -57,6 +57,7 @@ fun ProfileInputForm(
             )
             PhoneNumberInput(
                 value = phoneNumber,
+                prefix = profile.phoneNumberPrefix,
                 onValueChange = { onEvent(PhoneNumberChanged(it)) },
                 error = phoneNumberError.asString(),
                 isEnabled = isPhoneNumberEnabled,


### PR DESCRIPTION
Prefix and phone number are splitted to prevent this kind of issues and support further prefix changing implementation.

- moved prefix constant to common module
- splitted prefix and phone number in places of use
- refactored `EnterPhoneViewModel` to use events

<details>
<summary>Demo:</summary>

https://user-images.githubusercontent.com/83027107/207864336-eb621d01-67c2-4056-a928-6ab76d7684ea.mp4
</details>

P.S. Prefix was changed only for testing purposes, you can check it in `DefaultConstants` object