### PR TITLE
EPMEDU-1533: Fix calculating route displaying after canceling feeding flow

### DIFF
--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
@@ -27,6 +27,7 @@ import com.epmedu.animeal.home.presentation.HomeScreenEvent.FeedingPointEvent.Fa
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.RouteEvent
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.TimerEvent
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.WillFeedEvent
+import com.epmedu.animeal.home.presentation.model.FeedingRouteState
 import com.epmedu.animeal.home.presentation.model.GpsSettingState
 import com.epmedu.animeal.home.presentation.model.WillFeedState
 import com.epmedu.animeal.home.presentation.ui.FeedingExpiredDialog
@@ -136,7 +137,7 @@ internal fun HomeScreenUI(
                 state = state,
                 onFeedingPointSelect = { onScreenEvent(FeedingPointEvent.Select(it)) },
                 onMapInteraction = {
-                    if (bottomSheetState.isExpanding && !state.feedingRouteState.isRouteActive) {
+                    if (bottomSheetState.isExpanding && state.feedingRouteState is FeedingRouteState.Disabled) {
                         scope.launch { bottomSheetState.show() }
                     }
                 },

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/model/FeedingRouteState.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/model/FeedingRouteState.kt
@@ -2,30 +2,14 @@ package com.epmedu.animeal.home.presentation.model
 
 import com.mapbox.navigation.base.route.NavigationRoute
 
-sealed class FeedingRouteState(
-    val timeLeft: Long? = null,
-    val distanceLeft: Long? = null,
-    val isRouteActive: Boolean = false,
-    val routeData: NavigationRoute? = null,
-    val isError: Boolean = false
-) {
-    object Disabled : FeedingRouteState(
-        timeLeft = null,
-        distanceLeft = null,
-        isRouteActive = false,
-        isError = false
-    )
+sealed interface FeedingRouteState {
 
-    class Active(
-        distanceLeft: Long? = null,
-        timeLeft: Long? = null,
-        routeData: NavigationRoute? = null,
-        isError: Boolean = false
-    ) : FeedingRouteState(
-        timeLeft = timeLeft,
-        distanceLeft = distanceLeft,
-        isRouteActive = true,
-        routeData = routeData,
-        isError = isError
-    )
+    object Disabled : FeedingRouteState
+
+    data class Active(
+        val distanceLeft: Long? = null,
+        val timeLeft: Long? = null,
+        val routeData: NavigationRoute? = null,
+        val isError: Boolean = false
+    ) : FeedingRouteState
 }

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/HomeMapbox.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/HomeMapbox.kt
@@ -19,6 +19,7 @@ import com.epmedu.animeal.feeding.presentation.model.FeedingPointModel
 import com.epmedu.animeal.feeding.presentation.model.MapLocation
 import com.epmedu.animeal.foundation.switch.AnimealSwitch
 import com.epmedu.animeal.foundation.theme.bottomBarPadding
+import com.epmedu.animeal.home.presentation.model.FeedingRouteState
 import com.epmedu.animeal.home.presentation.model.RouteResult
 import com.epmedu.animeal.home.presentation.ui.map.GesturesListener
 import com.epmedu.animeal.home.presentation.ui.map.MapBoxInitOptions
@@ -60,15 +61,7 @@ internal fun HomeMapbox(
             onMapInteraction = onMapInteraction,
         )
 
-        if (!state.feedingRouteState.isRouteActive) {
-            AnimealSwitch(
-                modifier = Modifier
-                    .statusBarsPadding()
-                    .align(alignment = Alignment.TopCenter)
-                    .padding(top = 24.dp),
-                onSelectTab = {}
-            )
-        } else {
+        if (state.feedingRouteState is FeedingRouteState.Active) {
             RouteTopBar(
                 modifier = Modifier
                     .statusBarsPadding()
@@ -80,6 +73,14 @@ internal fun HomeMapbox(
                     " • ${context.formatMetersToKilometers(this)}"
                 } ?: "",
                 onCancelClick = onCancelRouteClick
+            )
+        } else {
+            AnimealSwitch(
+                modifier = Modifier
+                    .statusBarsPadding()
+                    .align(alignment = Alignment.TopCenter)
+                    .padding(top = 24.dp),
+                onSelectTab = {}
             )
         }
 
@@ -115,7 +116,7 @@ private fun MapboxMap(
     // so we have to make sure the map is loaded before setting location
     val onStyleLoadedListener = OnStyleLoadedListener { event ->
         event.end?.run {
-            if (state.feedingRouteState.isRouteActive) {
+            if (state.feedingRouteState is FeedingRouteState.Active) {
                 setLocationOnRoute(mapboxMapView, state)
             } else {
                 mapboxMapView.setLocation(state.locationState.location)

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/HomeMapbox.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/HomeMapbox.kt
@@ -61,27 +61,30 @@ internal fun HomeMapbox(
             onMapInteraction = onMapInteraction,
         )
 
-        if (state.feedingRouteState is FeedingRouteState.Active) {
-            RouteTopBar(
-                modifier = Modifier
-                    .statusBarsPadding()
-                    .padding(top = 16.dp)
-                    .padding(horizontal = 20.dp),
-                timeLeft = context.formatNumberToHourMin(state.feedingRouteState.timeLeft)
-                    ?: stringResource(R.string.calculating_route),
-                distanceLeft = state.feedingRouteState.distanceLeft?.run {
-                    " • ${context.formatMetersToKilometers(this)}"
-                } ?: "",
-                onCancelClick = onCancelRouteClick
-            )
-        } else {
-            AnimealSwitch(
-                modifier = Modifier
-                    .statusBarsPadding()
-                    .align(alignment = Alignment.TopCenter)
-                    .padding(top = 24.dp),
-                onSelectTab = {}
-            )
+        when (state.feedingRouteState) {
+            is FeedingRouteState.Disabled -> {
+                AnimealSwitch(
+                    modifier = Modifier
+                        .statusBarsPadding()
+                        .align(alignment = Alignment.TopCenter)
+                        .padding(top = 24.dp),
+                    onSelectTab = {}
+                )
+            }
+            is FeedingRouteState.Active -> {
+                RouteTopBar(
+                    modifier = Modifier
+                        .statusBarsPadding()
+                        .padding(top = 16.dp)
+                        .padding(horizontal = 20.dp),
+                    timeLeft = context.formatNumberToHourMin(state.feedingRouteState.timeLeft)
+                        ?: stringResource(R.string.calculating_route),
+                    distanceLeft = state.feedingRouteState.distanceLeft?.run {
+                        " • ${context.formatMetersToKilometers(this)}"
+                    } ?: "",
+                    onCancelClick = onCancelRouteClick
+                )
+            }
         }
 
         GeoLocationFloatingActionButton(
@@ -116,10 +119,9 @@ private fun MapboxMap(
     // so we have to make sure the map is loaded before setting location
     val onStyleLoadedListener = OnStyleLoadedListener { event ->
         event.end?.run {
-            if (state.feedingRouteState is FeedingRouteState.Active) {
-                setLocationOnRoute(mapboxMapView, state)
-            } else {
-                mapboxMapView.setLocation(state.locationState.location)
+            when (state.feedingRouteState) {
+                is FeedingRouteState.Disabled -> mapboxMapView.setLocation(state.locationState.location)
+                is FeedingRouteState.Active -> setLocationOnRoute(mapboxMapView, state)
             }
         }
     }

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
@@ -12,6 +12,7 @@ import com.epmedu.animeal.home.presentation.viewmodel.HomeState
 import com.epmedu.animeal.timer.data.model.TimerState
 import com.mapbox.maps.MapView
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 
@@ -44,10 +45,12 @@ internal fun RouteView(
             state.feedingRouteState is FeedingRouteState.Active &&
                 state.timerState is TimerState.Active -> {
                 if (state.feedingRouteState.routeData != null) {
-                    mapView.drawRoute(mapBoxRouteInitOptions, state.feedingRouteState.routeData)
-                    if (mapView.getMapboxMap().getStyle()?.isStyleLoaded == true) {
-                        setLocationOnRoute(mapView, state)
-                    }
+                    drawRoute(
+                        state,
+                        state.feedingRouteState.routeData,
+                        mapView,
+                        mapBoxRouteInitOptions
+                    )
                 } else {
                     fetchRoute(
                         state,
@@ -75,6 +78,20 @@ internal fun setLocationOnRoute(mapView: MapView, state: HomeState) {
                 feedingPointLocation
             )
         )
+    }
+}
+
+private fun drawRoute(
+    state: HomeState,
+    routeData: NavigationRoute?,
+    mapView: MapView,
+    mapBoxRouteInitOptions: MapBoxRouteInitOptions
+) {
+    routeData?.let {
+        mapView.drawRoute(mapBoxRouteInitOptions, it)
+    }
+    if (mapView.getMapboxMap().getStyle()?.isStyleLoaded == true) {
+        setLocationOnRoute(mapView, state)
     }
 }
 

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
@@ -44,7 +44,10 @@ internal fun RouteView(
             state.feedingRouteState is FeedingRouteState.Active &&
                 state.timerState is TimerState.Active -> {
                 if (state.feedingRouteState.routeData != null) {
-                    drawRoute(state, mapView, mapBoxRouteInitOptions)
+                    mapView.drawRoute(mapBoxRouteInitOptions, state.feedingRouteState.routeData)
+                    if (mapView.getMapboxMap().getStyle()?.isStyleLoaded == true) {
+                        setLocationOnRoute(mapView, state)
+                    }
                 } else {
                     fetchRoute(
                         state,
@@ -72,19 +75,6 @@ internal fun setLocationOnRoute(mapView: MapView, state: HomeState) {
                 feedingPointLocation
             )
         )
-    }
-}
-
-private fun drawRoute(
-    state: HomeState,
-    mapView: MapView,
-    mapBoxRouteInitOptions: MapBoxRouteInitOptions
-) {
-    state.feedingRouteState.routeData?.let {
-        mapView.drawRoute(mapBoxRouteInitOptions, it)
-    }
-    if (mapView.getMapboxMap().getStyle()?.isStyleLoaded == true) {
-        setLocationOnRoute(mapView, state)
     }
 }
 

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/handlers/feeding/DefaultFeedingHandler.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/handlers/feeding/DefaultFeedingHandler.kt
@@ -63,8 +63,8 @@ internal class DefaultFeedingHandler @Inject constructor(
             action = cancelFeedingUseCase::invoke,
             onSuccess = {
                 stopRoute()
-                fetchFeedingPoints()
                 disableTimer()
+                fetchFeedingPoints()
             }
         )
     }

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/handlers/route/DefaultRouteHandler.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/handlers/route/DefaultRouteHandler.kt
@@ -29,26 +29,30 @@ internal class DefaultRouteHandler @Inject constructor(
     }
 
     private fun updateRoute(event: FeedingRouteUpdateRequest) {
-        updateState {
-            copy(
-                feedingRouteState = FeedingRouteState.Active(
-                    event.result.distanceLeft,
-                    state.feedingRouteState.timeLeft,
-                    event.result.routeData
+        if (state.feedingRouteState is FeedingRouteState.Active) {
+            updateState {
+                copy(
+                    feedingRouteState = FeedingRouteState.Active(
+                        event.result.distanceLeft,
+                        state.feedingRouteState.timeLeft,
+                        event.result.routeData
+                    )
                 )
-            )
+            }
         }
     }
 
     private fun updateTimer(event: FeedingTimerUpdateRequest) {
-        updateState {
-            copy(
-                feedingRouteState = FeedingRouteState.Active(
-                    state.feedingRouteState.distanceLeft,
-                    event.timeLeft,
-                    state.feedingRouteState.routeData
+        if (state.feedingRouteState is FeedingRouteState.Active) {
+            updateState {
+                copy(
+                    feedingRouteState = FeedingRouteState.Active(
+                        state.feedingRouteState.distanceLeft,
+                        event.timeLeft,
+                        state.feedingRouteState.routeData
+                    )
                 )
-            )
+            }
         }
     }
 }


### PR DESCRIPTION
- Reordered timer disabling and feeding points fetching in `FeedingHandler`
- Refactored `FeedingRouteState` to sealed interface to reduce number of recompositions

https://user-images.githubusercontent.com/83027107/223411815-529f9176-15f0-4f25-b132-232008a4c06b.mp4

