### PR TITLE
Enable Charles debugging in release builds for QA team

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
 
-    <debug-overrides>
+<!--Temporary solution to allow testers use Charles TODO: Separate into flavors-->
+    <base-config>
 
         <trust-anchors>
 
             <certificates src="user" />
+            <certificates src="system"/>
 
         </trust-anchors>
 
-    </debug-overrides>
+    </base-config>
 
 </network-security-config>


### PR DESCRIPTION
Modified `network_security_config.xml` to allow QA team use Charles in release builds.
We will create separate flavors for that later.