### PR TITLE
Fix sign in after session expiring

### DIFF
--- a/library/auth/src/main/java/com/epmedu/animeal/auth/AuthAPI.kt
+++ b/library/auth/src/main/java/com/epmedu/animeal/auth/AuthAPI.kt
@@ -5,6 +5,7 @@ import com.amplifyframework.auth.AuthUserAttributeKey
 import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
 import com.amplifyframework.auth.cognito.options.AWSCognitoAuthSignInOptions
 import com.amplifyframework.auth.cognito.options.AuthFlowType
+import com.amplifyframework.auth.exceptions.SessionExpiredException
 import com.amplifyframework.auth.options.AuthSignUpOptions
 import com.amplifyframework.auth.result.AuthSessionResult
 import com.amplifyframework.core.Amplify
@@ -17,6 +18,15 @@ class AuthAPI {
 
     var authenticationType: AuthenticationType = AuthenticationType.Mobile
         private set
+
+    private val AWSCognitoAuthSession.isExpired
+        get() = isSignedIn.not() &&
+            (
+                awsCredentialsResult.error is SessionExpiredException ||
+                    identityIdResult.error is SessionExpiredException ||
+                    userPoolTokensResult.error is SessionExpiredException ||
+                    userSubResult.error is SessionExpiredException
+                )
 
     private val AWSCognitoAuthSession.isSignedInWithoutErrors
         get() = isSignedIn &&
@@ -40,12 +50,28 @@ class AuthAPI {
         return suspendCancellableCoroutine {
             Amplify.Auth.fetchAuthSession(
                 { session ->
-                    resume(
-                        when (session) {
-                            is AWSCognitoAuthSession -> session.isSignedInWithoutErrors
-                            else -> session.isSignedIn
+                    when (session) {
+                        is AWSCognitoAuthSession -> {
+                            if (session.isExpired) {
+                                signOut(
+                                    object : AuthRequestHandler {
+                                        override fun onSuccess(result: Any?) {
+                                            resume(false)
+                                        }
+
+                                        override fun onError(exception: Exception) {
+                                            resume(false)
+                                        }
+                                    }
+                                )
+                            } else {
+                                resume(session.isSignedInWithoutErrors)
+                            }
                         }
-                    )
+                        else -> {
+                            resume(session.isSignedIn)
+                        }
+                    }
                 },
                 {
                     resume(false)


### PR DESCRIPTION
It turned out that in the new Amplify version we have to sign out manually when session is expired. 
Otherwise, we receive a `SignedInException` on trying to sign in.