### PR TITLE
epmedu-1777: Part-1 support navigation with arguments

### DIFF
--- a/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/TabsHost.kt
+++ b/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/TabsHost.kt
@@ -12,8 +12,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.epmedu.animeal.common.constants.Arguments.ANIMAL_TYPE
+import com.epmedu.animeal.common.constants.Arguments.FORCED_FEEDING_POINT_ID
 import com.epmedu.animeal.common.route.TabsRoute
 import com.epmedu.animeal.favourites.presentation.FavouritesScreen
 import com.epmedu.animeal.foundation.animation.VerticalSlideAnimatedVisibility
@@ -94,11 +98,23 @@ private fun NavigationTabs(
 ) {
     ScreenNavHost(
         navController = navigationController,
-        startDestination = NavigationTab.Home.route.name
+        startDestination = TabsRoute.Home.format(FORCED_FEEDING_POINT_ID, ANIMAL_TYPE)
     ) {
         screen(TabsRoute.Search.name) { SearchScreen() }
         screen(TabsRoute.Favourites.name) { FavouritesScreen() }
-        screen(TabsRoute.Home.name) { HomeScreen() }
+        screen(
+            route = TabsRoute.Home.format(FORCED_FEEDING_POINT_ID, ANIMAL_TYPE),
+            arguments = listOf(
+                navArgument(FORCED_FEEDING_POINT_ID) {
+                    type = NavType.StringType
+                    nullable = true
+                },
+                navArgument(ANIMAL_TYPE) {
+                    type = NavType.StringType
+                    nullable = true
+                }
+            )
+        ) { HomeScreen() }
         screen(TabsRoute.Analytics.name) { AnalyticsScreen() }
         screen(TabsRoute.More.name) { MoreHost() }
     }

--- a/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/TabsHost.kt
+++ b/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/TabsHost.kt
@@ -38,7 +38,7 @@ fun TabsHost() {
 
     val navigationController = rememberNavController()
     val navBackStackEntry by navigationController.currentBackStackEntryAsState()
-    val currentRoute = navBackStackEntry?.destination?.route
+    val currentRoute: TabsRoute? = TabsRoute.fromRoutePath(navBackStackEntry?.destination?.route)
     var bottomBarVisibility by rememberSaveable { mutableStateOf(SHOWN) }
     val onChangeBottomBarVisibility = { visibility: BottomBarVisibilityState ->
         bottomBarVisibility = visibility

--- a/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/ui/BottomAppBarFab.kt
+++ b/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/ui/BottomAppBarFab.kt
@@ -26,7 +26,7 @@ import com.epmedu.animeal.tabs.NavigationTab
 
 @Composable
 internal fun BottomAppBarFab(
-    currentRoute: String?,
+    currentRoute: TabsRoute?,
     associatedScreen: NavigationTab = NavigationTab.Home,
     onNavigate: (TabsRoute) -> Unit
 ) {
@@ -57,7 +57,7 @@ internal fun BottomAppBarFab(
                 modifier = Modifier
                     .background(
                         when (currentRoute) {
-                            route.name -> MaterialTheme.colors.primary
+                            route -> MaterialTheme.colors.primary
                             else -> MaterialTheme.colors.surface
                         }
                     )
@@ -70,7 +70,7 @@ internal fun BottomAppBarFab(
                     painter = painterResource(id = R.drawable.ic_home),
                     contentDescription = stringResource(associatedScreen.contentDescription),
                     tint = when (currentRoute) {
-                        route.name -> MaterialTheme.colors.surface
+                        route -> MaterialTheme.colors.surface
                         else -> MaterialTheme.colors.onSurface
                     }
                 )
@@ -85,11 +85,11 @@ private fun BottomAppBarFabPreview() {
     AnimealTheme {
         Column {
             BottomAppBarFab(
-                currentRoute = NavigationTab.Home.route.name,
+                currentRoute = NavigationTab.Home.route,
                 onNavigate = {},
             )
             BottomAppBarFab(
-                currentRoute = NavigationTab.More.route.name,
+                currentRoute = NavigationTab.More.route,
                 onNavigate = {},
             )
         }

--- a/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/ui/BottomNavigationBar.kt
+++ b/feature/tabsflow/tabs/src/main/java/com/epmedu/animeal/tabs/ui/BottomNavigationBar.kt
@@ -20,7 +20,7 @@ import com.epmedu.animeal.tabs.NavigationTab
 
 @Composable
 internal fun BottomNavigationBar(
-    currentRoute: String?,
+    currentRoute: TabsRoute?,
     onNavigate: (TabsRoute) -> Unit
 ) {
     val items = listOf(
@@ -48,7 +48,7 @@ internal fun BottomNavigationBar(
                     selectedContentColor = MaterialTheme.colors.primary,
                     unselectedContentColor = MaterialTheme.colors.onSurface,
                     alwaysShowLabel = false,
-                    selected = currentRoute == item.route.name,
+                    selected = currentRoute == item.route,
                     onClick = {
                         onNavigate(item.route)
                     }
@@ -64,12 +64,12 @@ private fun BottomNavigationBarPreview() {
     AnimealTheme {
         Column {
             BottomNavigationBar(
-                currentRoute = NavigationTab.Search.route.name,
+                currentRoute = NavigationTab.Search.route,
                 onNavigate = {}
             )
             Divider()
             BottomNavigationBar(
-                currentRoute = NavigationTab.More.route.name,
+                currentRoute = NavigationTab.More.route,
                 onNavigate = {}
             )
         }

--- a/library/common/src/main/java/com/epmedu/animeal/common/constants/Arguments.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/constants/Arguments.kt
@@ -1,0 +1,6 @@
+package com.epmedu.animeal.common.constants
+
+object Arguments {
+    const val FORCED_FEEDING_POINT_ID = "forced_feeding_point_id"
+    const val ANIMAL_TYPE = "animal_type"
+}

--- a/library/common/src/main/java/com/epmedu/animeal/common/route/RouteWithArgs.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/route/RouteWithArgs.kt
@@ -1,0 +1,21 @@
+package com.epmedu.animeal.common.route
+
+interface RouteWithArgs {
+    val name: String
+
+    fun withArg(vararg args: Pair<String, String>): String =
+        buildString {
+            append(name)
+            args.forEach { (arg, value) ->
+                append("?$arg=$value")
+            }
+        }
+
+    fun format(vararg args: String): String =
+        buildString {
+            append(name)
+            args.forEach {
+                append("?$it={$it}")
+            }
+        }
+}

--- a/library/common/src/main/java/com/epmedu/animeal/common/route/TabsRoute.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/route/TabsRoute.kt
@@ -1,6 +1,6 @@
 package com.epmedu.animeal.common.route
 
-enum class TabsRoute {
+enum class TabsRoute : RouteWithArgs {
     Search,
     Favourites,
     Home,

--- a/library/common/src/main/java/com/epmedu/animeal/common/route/TabsRoute.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/route/TabsRoute.kt
@@ -5,5 +5,14 @@ enum class TabsRoute {
     Favourites,
     Home,
     Analytics,
-    More
+    More;
+    companion object {
+        fun fromRoutePath(routeName: String?): TabsRoute? {
+            routeName ?: return null
+
+            return TabsRoute.values().firstOrNull {
+                routeName.contains(it.name)
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is the first part of the complex solution for the ticket: https://jira.epam.com/jira/browse/EPMEDU-1777

The idea is to support opening the Home screen with arguments. 
Since the user would be able to open the feeding point by the link on the Favorites and Search tabs, we should support opening the Home Tab with the type of the feeding point (AnimalType) and the feedingPointId directly.

The solution will be extended in the next PRs