### PR TITLE
Deprecate EventDelegate

### DIFF
--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/EventDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/EventDelegate.kt
@@ -2,6 +2,14 @@ package com.epmedu.animeal.common.presentation.viewmodel.delegate
 
 import kotlinx.coroutines.flow.SharedFlow
 
+@Deprecated(
+    message = """ViewModel events is an antipattern. 
+            Usages of this interface should be replaced with StateDelegate or moved to UI if there is no business logic.
+            Please read the following article to learn more: 
+            https://medium.com/androiddevelopers/viewmodel-one-off-event-antipatterns-16a1da869b95""",
+    replaceWith = ReplaceWith("StateDelegate"),
+    level = DeprecationLevel.WARNING
+)
 interface EventDelegate<Event> {
 
     val events: SharedFlow<Event>

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/EventDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/EventDelegate.kt
@@ -3,7 +3,7 @@ package com.epmedu.animeal.common.presentation.viewmodel.delegate
 import kotlinx.coroutines.flow.SharedFlow
 
 @Deprecated(
-    message = """ViewModel events is an antipattern. 
+    message = """ViewModel events is an antipattern.
             Usages of this interface should be replaced with StateDelegate or moved to UI if there is no business logic.
             Please read the following article to learn more: 
             https://medium.com/androiddevelopers/viewmodel-one-off-event-antipatterns-16a1da869b95""",


### PR DESCRIPTION
ViewModel events is an antipattern that we used due to lack of experience.
UI must only receive information from the view model through state, otherwise it will break the unidirectional data flow and this information may be lost.
The `EventDelegate` interface should be removed in the future and its usages should be replaced by `StateDelegate` or moved to UI if there is no business logic.

[Learn more](https://medium.com/androiddevelopers/viewmodel-one-off-event-antipatterns-16a1da869b95)