### PR TITLE
[EPMEDU-1871]: The Confirmation (cancel registration) modal window closes when tapping outside the modal window

### DIFF
--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/dialog/AnimealQuestionDialog.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/dialog/AnimealQuestionDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import com.epmedu.animeal.foundation.button.AnimealButton
 import com.epmedu.animeal.foundation.button.AnimealSecondaryButtonOutlined
 import com.epmedu.animeal.foundation.preview.AnimealPreview
@@ -64,7 +65,11 @@ fun AnimealQuestionDialog(
                     },
                 )
             }
-        }
+        },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false
+        )
     )
 }
 


### PR DESCRIPTION
[Issue link](https://jira.epam.com/jira/browse/EPMEDU-1871)

- Disabled dismissing on tapping outside of `AnimealQuestionDialog`
- Disabled dismissing of `AnimealQuestionDialog` on pressing back button

https://user-images.githubusercontent.com/83027107/233730963-a420a45b-42eb-4b71-b239-9012661f6361.mp4