### PR TITLE
[EPMEDU-1848]: Wrong font colour of the "Cancel" button on the "Profile" page

### DIFF
--- a/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/ui/FinishProfileButtonsRow.kt
+++ b/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/ui/FinishProfileButtonsRow.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.epmedu.animeal.foundation.button.AnimealButton
-import com.epmedu.animeal.foundation.button.AnimealSecondaryButton
+import com.epmedu.animeal.foundation.button.AnimealSecondaryButtonOutlined
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.resources.R
@@ -22,7 +22,7 @@ internal fun FinishProfileButtonsRow(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        AnimealSecondaryButton(
+        AnimealSecondaryButtonOutlined(
             modifier = Modifier.weight(1f),
             text = stringResource(id = R.string.cancel),
             onClick = onCancelClick,


### PR DESCRIPTION
- Set `AnimealSecondaryButtonOutlined` instead of `AnimealSecondaryButton` for Cancel button

![image](https://user-images.githubusercontent.com/83027107/233740166-2901d611-dcc6-4d7b-99cf-a935c66bc7bb.png)
