### PR TITLE
[EPMEDU-1928]: Black screen instead of map

### DIFF
--- a/feature/home/src/main/java/com/epmedu/animeal/home/di/HomePresentationModule.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/di/HomePresentationModule.kt
@@ -4,6 +4,7 @@ package com.epmedu.animeal.home.di
 
 import com.epmedu.animeal.camera.domain.usecase.DeletePhotoUseCase
 import com.epmedu.animeal.camera.domain.usecase.UploadPhotoUseCase
+import com.epmedu.animeal.common.component.BuildConfigProvider
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.ActionDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.DefaultEventDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.DefaultStateDelegate
@@ -57,7 +58,14 @@ internal object HomePresentationModule {
 
     @ViewModelScoped
     @Provides
-    fun providesStateDelegate(): StateDelegate<HomeState> = DefaultStateDelegate(HomeState())
+    fun providesStateDelegate(
+        buildConfigProvider: BuildConfigProvider
+    ): StateDelegate<HomeState> = DefaultStateDelegate(
+        initialState = HomeState(
+            mapBoxPublicKey = buildConfigProvider.mapBoxPublicKey,
+            mapBoxStyleUri = buildConfigProvider.mapBoxStyleURI
+        )
+    )
 
     @ViewModelScoped
     @Provides

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeState.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeState.kt
@@ -12,19 +12,19 @@ import com.epmedu.animeal.home.presentation.model.FeedingConfirmationState
 import com.epmedu.animeal.home.presentation.model.FeedingRouteState
 import com.epmedu.animeal.home.presentation.model.GpsSettingState
 import com.epmedu.animeal.timer.data.model.TimerState
-import com.mapbox.maps.Style
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 data class HomeState(
+    val mapBoxPublicKey: String,
+    val mapBoxStyleUri: String,
+
     val currentFeedingPoint: FeedingPointModel? = null,
     val feedingPoints: ImmutableList<FeedingPointModel> = persistentListOf(),
     val feedingRouteState: FeedingRouteState = FeedingRouteState.Disabled,
     val feedingPhotos: List<FeedingPhotoItem> = emptyList(),
     val willFeedState: WillFeedState = WillFeedState.Dismissed,
     val feedingConfirmationState: FeedingConfirmationState = FeedingConfirmationState.Dismissed,
-    val mapBoxPublicKey: String = "",
-    val mapBoxStyleUri: String = Style.MAPBOX_STREETS,
     val defaultAnimalType: AnimalType = AnimalType.Dogs,
 
     val locationState: LocationState = LocationState.UndefinedLocation(MapLocation.Tbilisi),

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -3,7 +3,6 @@ package com.epmedu.animeal.home.presentation.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.epmedu.animeal.common.component.BuildConfigProvider
 import com.epmedu.animeal.common.constants.Arguments.FORCED_FEEDING_POINT_ID
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.ActionDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.EventDelegate
@@ -83,7 +82,6 @@ internal class HomeViewModel @Inject constructor(
     ErrorHandler by defaultHomeHandler,
     LocationProvider by homeProviders,
     GpsSettingsProvider by homeProviders,
-    BuildConfigProvider by homeProviders,
     FeedingPhotoGalleryHandler by photoGalleryHandler {
 
     init {
@@ -138,8 +136,6 @@ internal class HomeViewModel @Inject constructor(
             val defaultAnimalType = animalTypeUseCase()
             updateState {
                 copy(
-                    mapBoxPublicKey = homeProviders.mapBoxPublicKey,
-                    mapBoxStyleUri = mapBoxStyleURI,
                     isInitialGeolocationPermissionAsked = getGeolocationPermissionRequestedSettingUseCase(),
                     gpsSettingState = when {
                         isGpsSettingsEnabled -> GpsSettingState.Enabled

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/providers/HomeProviders.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/providers/HomeProviders.kt
@@ -1,17 +1,11 @@
 package com.epmedu.animeal.home.presentation.viewmodel.providers
 
-import com.epmedu.animeal.common.component.BuildConfigProvider
-import com.epmedu.animeal.feeding.domain.repository.FeedingPointRepository
 import com.epmedu.animeal.geolocation.gpssetting.GpsSettingsProvider
 import com.epmedu.animeal.geolocation.location.LocationProvider
 import javax.inject.Inject
 
 class HomeProviders @Inject constructor(
-    private val buildConfigProvider: BuildConfigProvider,
     private val locationProvider: LocationProvider,
-    private val gpsSettingsProvider: GpsSettingsProvider,
-    private val feedingPointRepository: FeedingPointRepository
-) : BuildConfigProvider by buildConfigProvider,
-    LocationProvider by locationProvider,
-    GpsSettingsProvider by gpsSettingsProvider,
-    FeedingPointRepository by feedingPointRepository
+    private val gpsSettingsProvider: GpsSettingsProvider
+) : LocationProvider by locationProvider,
+    GpsSettingsProvider by gpsSettingsProvider


### PR DESCRIPTION
**Card**: https://jira.epam.com/jira/browse/EPMEDU-1928


### Description
The issue was that the style could not be retrieved as we provided the mapbox public key and style uri to the mapbox view too late and it was sending requests with an empty string as the token:
![image](https://user-images.githubusercontent.com/83027107/236639869-6f9b2c76-6583-483f-bc6c-541288143a21.png)

 - Replaced updating `HomeState` with MapBox public key and style uri by creating it with these variables initially
  - Removed `BuildConfigProvider` and `FeedingPointRepository` from `HomeProviders` and `HomeViewModel`

### Demo
| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/83027107/236639545-13dd0f0b-ce1f-426b-873d-e5e2ccdbfe62.mp4">  | <video src="https://user-images.githubusercontent.com/83027107/236639558-5d1709cf-03a1-4acd-96e2-b41fd3ef0e3f.mp4">  |