### PR TITLE
EPMEDU-1894: Crash related to regions on old devices

### DIFF
--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/domain/model/Region.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/domain/model/Region.kt
@@ -6,6 +6,7 @@
 
 package com.epmedu.animeal.profile.domain.model
 
+import androidx.emoji2.text.EmojiCompat
 import com.epmedu.animeal.extensions.toIntArray
 import java.util.*
 
@@ -225,4 +226,13 @@ fun Region.getFormat(): String {
         val digits = phoneNumberDigitsCount.last()
         (1..digits).joinToString("") { "x" }
     }
+}
+
+fun Region.codesListText(): String {
+    val emojiCompat = EmojiCompat.get()
+    val flag = when (emojiCompat.loadState) {
+        EmojiCompat.LOAD_STATE_SUCCEEDED -> emojiCompat.process(flagEmoji())
+        else -> flagEmoji()
+    }
+    return "$flag $phoneNumberCode ${countryName()}"
 }

--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/RegionsLazyColumn.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/RegionsLazyColumn.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.emoji2.text.EmojiCompat
+import androidx.emoji2.text.EmojiCompat.LOAD_STATE_SUCCEEDED
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.profile.domain.model.Region
@@ -63,5 +64,10 @@ fun RegionsLazyColumnPreview() {
 }
 
 private fun Region.codesListText(): String {
-    return "${EmojiCompat.get().process(flagEmoji())} $phoneNumberCode ${countryName()}"
+    val emojiCompat = EmojiCompat.get()
+    val flag = when (emojiCompat.loadState) {
+        LOAD_STATE_SUCCEEDED -> emojiCompat.process(flagEmoji())
+        else -> flagEmoji()
+    }
+    return "$flag $phoneNumberCode ${countryName()}"
 }

--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/RegionsLazyColumn.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/RegionsLazyColumn.kt
@@ -16,13 +16,11 @@ import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.emoji2.text.EmojiCompat
-import androidx.emoji2.text.EmojiCompat.LOAD_STATE_SUCCEEDED
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.profile.domain.model.Region
+import com.epmedu.animeal.profile.domain.model.codesListText
 import com.epmedu.animeal.profile.domain.model.countryName
-import com.epmedu.animeal.profile.domain.model.flagEmoji
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -65,13 +63,4 @@ fun RegionsLazyColumnPreview() {
             onRegionClick = {}
         )
     }
-}
-
-private fun Region.codesListText(): String {
-    val emojiCompat = EmojiCompat.get()
-    val flag = when (emojiCompat.loadState) {
-        LOAD_STATE_SUCCEEDED -> emojiCompat.process(flagEmoji())
-        else -> flagEmoji()
-    }
-    return "$flag $phoneNumberCode ${countryName()}"
 }

--- a/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/RegionsLazyColumn.kt
+++ b/shared/feature/profile/src/main/java/com/epmedu/animeal/profile/presentation/ui/RegionsLazyColumn.kt
@@ -35,7 +35,11 @@ fun RegionsLazyColumn(
     LazyColumn(
         modifier = Modifier.background(MaterialTheme.colors.background)
     ) {
-        items(Region.values()) { region ->
+        items(
+            items = Region.values().apply {
+                sortBy { region -> region.countryName() }
+            }
+        ) { region ->
             ListItem(
                 modifier = Modifier.clickable {
                     scope.launch { bottomSheetState.hide() }


### PR DESCRIPTION
**Card:** https://jira.epam.com/jira/browse/EPMEDU-1894

### Description
The issue was that the `EmojiCompat.process()` method was throwing `IllegalStateException`  when `EmojiCompat` was not properly initialized. For example, on Pixel 2 emulator with API 24 `EmojiCompatInitializer` is throwing `RuntimeException("EmojiCompat font provider not available on this device")` which leads to failed load state.

- Added emoji compat load state check
- Added sorting regions by country names

### Demo
| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/83027107/236642923-95b76e8d-f9e8-4f12-a5e7-6befb80ddebd.webm"> | <video src="https://user-images.githubusercontent.com/83027107/236642785-b1dedc8d-48c8-40d6-811b-b35f087902a7.webm"> |

