### PR TITLE
[EPMEDU-1962]: Timer for current feeding is not correct

### DIFF
--- a/library/common/src/main/java/com/epmedu/animeal/common/timer/TickerFlow.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/timer/TickerFlow.kt
@@ -1,13 +1,19 @@
 package com.epmedu.animeal.common.timer
 
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.channelFlow
+import android.os.CountDownTimer
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
 
-suspend fun tickerFlow(millisInFuture: Long, countDownInterval: Long) = channelFlow {
-    var timeLeft = millisInFuture
-    while (timeLeft > 0) {
-        trySend(timeLeft)
-        timeLeft -= countDownInterval
-        delay(countDownInterval)
+suspend fun tickerFlow(millisInFuture: Long, countDownInterval: Long) = callbackFlow {
+    val timer = object : CountDownTimer(millisInFuture, countDownInterval) {
+        override fun onTick(millisUntilFinished: Long) {
+            trySend(millisUntilFinished)
+        }
+
+        override fun onFinish() {
+            close()
+        }
     }
+    timer.start()
+    awaitClose { timer.cancel() }
 }

--- a/shared/feature/timer/src/main/java/com/epmedu/animeal/timer/data/repository/TimerRepositoryImpl.kt
+++ b/shared/feature/timer/src/main/java/com/epmedu/animeal/timer/data/repository/TimerRepositoryImpl.kt
@@ -19,7 +19,7 @@ internal class TimerRepositoryImpl : TimerRepository {
 
     private val timerFlow = MutableStateFlow(timerState)
 
-    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     private var job: Job? = null
 
@@ -35,7 +35,7 @@ internal class TimerRepositoryImpl : TimerRepository {
     override fun getTimerState() = timerFlow.asStateFlow()
 
     override suspend fun disableTimer() {
-        job?.run { cancel() }
+        job?.cancel()
         timerState = TimerState.Disabled
         timerFlow.emit(timerState)
     }


### PR DESCRIPTION
  - Replaced while-delay with `CountDownTimer`

Why? It's more stable in background. 
I tried to log ticks for current implementation and for `CountDownTimer` and here what I got:

I launched the app, started feeding flow, waited for 1 minute and then locked the phone. Next minute after this was logged, but then logs were stopped until I unlocked the device (after 5-10 minutes, see the timestamps)
| Current while-delay  | <img width="927" alt="MicrosoftTeams-image" src="https://github.com/AnimealProject/animeal_android/assets/83027107/a801e5e1-80c3-49de-88b5-b454c5ebc87a"> |
| ------------- | ------------- |
| CountDownTimer | <img width="931" alt="MicrosoftTeams-image (2)" src="https://github.com/AnimealProject/animeal_android/assets/83027107/12226745-5972-4b56-a5b6-4061799d2a4b">  |
| Logs Setup | <img width="1220" alt="MicrosoftTeams-image (3)" src="https://github.com/AnimealProject/animeal_android/assets/83027107/2253e70b-b745-4a42-963a-a6d25c983bb6">  |