### PR TITLE
[EPMEDU-1923] Handle refresh token expiration on splash screen

### DIFF
--- a/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/viewmodel/OnboardingViewModel.kt
+++ b/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/viewmodel/OnboardingViewModel.kt
@@ -42,11 +42,16 @@ internal class OnboardingViewModel @Inject constructor(
 
     private fun saveAuthenticationTypeAndProfile() {
         viewModelScope.launch {
-            val isPhoneNumberVerified = performAction { getIsPhoneNumberVerifiedUseCase() }
-            changeAuthenticationTypeToFacebook(isPhoneNumberVerified)
-            performAction { getNetworkProfileUseCase() }?.let { profile ->
-                saveLocalProfile(profile, isPhoneNumberVerified)
-            }
+            performAction<Boolean>(
+                action = { getIsPhoneNumberVerifiedUseCase() },
+                onSuccess = { result ->
+                    changeAuthenticationTypeToFacebook(result)
+                    performAction { getNetworkProfileUseCase() }?.let { profile ->
+                        saveLocalProfile(profile, result)
+                    }
+                },
+                onError = {}
+            )
         }
     }
 

--- a/library/auth/src/main/java/com/epmedu/animeal/auth/AuthAPIImpl.kt
+++ b/library/auth/src/main/java/com/epmedu/animeal/auth/AuthAPIImpl.kt
@@ -44,6 +44,9 @@ internal class AuthAPIImpl : AuthAPI {
         )
     }
 
+    /** Keep in mind: verification of session expiration (session.isExpired) works only for Mobile authorization flow.
+     * Wherever this method is used for Facebook flow, verify that next steps will be ready to handle
+     * NotAuthorizedException due to possible refresh token expiration */
     override suspend fun isSignedIn(): Boolean {
         return suspendCancellableCoroutine {
             Amplify.Auth.fetchAuthSession(

--- a/library/common/src/main/java/com/epmedu/animeal/common/domain/wrapper/ActionResult.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/domain/wrapper/ActionResult.kt
@@ -1,8 +1,8 @@
 package com.epmedu.animeal.common.domain.wrapper
 
-sealed interface ActionResult {
+sealed interface ActionResult<out T> {
 
-    object Success : ActionResult
+    data class Success<out T : Any>(val result: T) : ActionResult<T>
 
-    data class Failure(val error: Throwable) : ActionResult
+    data class Failure(val error: Throwable) : ActionResult<Nothing>
 }

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
@@ -5,9 +5,15 @@ import com.epmedu.animeal.common.domain.wrapper.ActionResult
 interface ActionDelegate {
 
     suspend fun performAction(
-        action: suspend () -> ActionResult,
+        action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit = {},
         onError: () -> Unit = {},
+    )
+
+    suspend fun <T> performAction(
+        action: suspend () -> ActionResult<T>,
+        onSuccess: suspend (T) -> Unit,
+        onError: () -> Unit
     )
 
     suspend fun <T> performAction(

--- a/shared/feature/camera/src/main/java/com/epmedu/animeal/camera/data/repository/CameraRepositoryImpl.kt
+++ b/shared/feature/camera/src/main/java/com/epmedu/animeal/camera/data/repository/CameraRepositoryImpl.kt
@@ -7,17 +7,17 @@ import com.epmedu.animeal.common.data.wrapper.ApiResult
 import com.epmedu.animeal.common.domain.wrapper.ActionResult
 
 internal class CameraRepositoryImpl(private val storageApi: StorageApi) : CameraRepository {
-    override suspend fun uploadPhoto(fileName: String, fileUri: Uri): ActionResult {
+    override suspend fun uploadPhoto(fileName: String, fileUri: Uri): ActionResult<Unit> {
         return storageApi.uploadFile(fileName, fileUri).toActionResult()
     }
 
-    override suspend fun deletePhoto(fileName: String): ActionResult =
+    override suspend fun deletePhoto(fileName: String): ActionResult<Unit> =
         storageApi.deleteFile(fileName).toActionResult()
 }
 
-private fun ApiResult<Unit>.toActionResult(): ActionResult {
+private fun ApiResult<Unit>.toActionResult(): ActionResult<Unit> {
     return when (this) {
-        is ApiResult.Success -> ActionResult.Success
+        is ApiResult.Success -> ActionResult.Success(Unit)
         is ApiResult.Failure -> ActionResult.Failure(error)
     }
 }

--- a/shared/feature/camera/src/main/java/com/epmedu/animeal/camera/domain/repository/CameraRepository.kt
+++ b/shared/feature/camera/src/main/java/com/epmedu/animeal/camera/domain/repository/CameraRepository.kt
@@ -5,7 +5,7 @@ import com.epmedu.animeal.common.domain.wrapper.ActionResult
 
 interface CameraRepository {
 
-    suspend fun uploadPhoto(fileName: String, fileUri: Uri): ActionResult
+    suspend fun uploadPhoto(fileName: String, fileUri: Uri): ActionResult<Unit>
 
-    suspend fun deletePhoto(fileName: String): ActionResult
+    suspend fun deletePhoto(fileName: String): ActionResult<Unit>
 }

--- a/shared/feature/camera/src/main/java/com/epmedu/animeal/camera/domain/usecase/DeletePhotoUseCase.kt
+++ b/shared/feature/camera/src/main/java/com/epmedu/animeal/camera/domain/usecase/DeletePhotoUseCase.kt
@@ -7,27 +7,27 @@ import java.io.File
 
 class DeletePhotoUseCase(private val cameraRepository: CameraRepository) {
 
-    suspend operator fun invoke(uri: Uri, fileName: String): ActionResult =
+    suspend operator fun invoke(uri: Uri, fileName: String): ActionResult<Unit> =
         deleteRemoteFile(fileName) {
             deleteLocalFile(uri)
         }
 
     private suspend fun deleteRemoteFile(
         fileName: String,
-        success: () -> ActionResult
-    ): ActionResult =
+        success: () -> ActionResult<Unit>
+    ): ActionResult<Unit> =
         when (val result = cameraRepository.deletePhoto(fileName)) {
             is ActionResult.Failure -> result
-            ActionResult.Success -> success()
+            is ActionResult.Success<*> -> success()
         }
 
-    private fun deleteLocalFile(uri: Uri): ActionResult =
+    private fun deleteLocalFile(uri: Uri): ActionResult<Unit> =
         uri.path
             ?.let(::File)
             ?.takeIf { it.exists() }
             ?.run {
                 delete()
-                ActionResult.Success
+                ActionResult.Success(Unit)
             }
             ?: ActionResult.Failure(IllegalStateException("Can't delete the file by path ${uri.path}"))
 }

--- a/shared/feature/feeding/src/debug/java/com/epmedu/animeal/feeding/data/repository/FavouriteRepositoryMock.kt
+++ b/shared/feature/feeding/src/debug/java/com/epmedu/animeal/feeding/data/repository/FavouriteRepositoryMock.kt
@@ -20,22 +20,22 @@ internal class FavouriteRepositoryMock : FavouriteRepository {
         }
     }
 
-    override suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult {
+    override suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult<Unit> {
         favouritesFlow.update { favourites ->
             favourites + Favourite.builder()
                 .userId("")
                 .feedingPointId(feedingPointId)
                 .build()
         }
-        return ActionResult.Success
+        return ActionResult.Success(Unit)
     }
 
-    override suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult {
+    override suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult<Unit> {
         val favouriteToRemove = favourites.find { it.feedingPointId == feedingPointId }
 
         return favouriteToRemove?.let {
             favouritesFlow.value = favourites - favouriteToRemove
-            ActionResult.Success
+            ActionResult.Success(Unit)
         } ?: ActionResult.Failure(Throwable())
     }
 }

--- a/shared/feature/feeding/src/debug/java/com/epmedu/animeal/feeding/data/repository/FeedingRepositoryMock.kt
+++ b/shared/feature/feeding/src/debug/java/com/epmedu/animeal/feeding/data/repository/FeedingRepositoryMock.kt
@@ -23,23 +23,23 @@ internal class FeedingRepositoryMock : FeedingRepository {
         return flowOf(emptyList())
     }
 
-    override suspend fun startFeeding(feedingPointId: String): ActionResult {
-        return ActionResult.Success
+    override suspend fun startFeeding(feedingPointId: String): ActionResult<Unit> {
+        return ActionResult.Success(Unit)
     }
 
-    override suspend fun cancelFeeding(feedingPointId: String): ActionResult {
-        return ActionResult.Success
+    override suspend fun cancelFeeding(feedingPointId: String): ActionResult<Unit> {
+        return ActionResult.Success(Unit)
     }
 
-    override suspend fun rejectFeeding(feedingPointId: String, reason: String): ActionResult {
-        return ActionResult.Success
+    override suspend fun rejectFeeding(feedingPointId: String, reason: String): ActionResult<Unit> {
+        return ActionResult.Success(Unit)
     }
 
     override suspend fun finishFeeding(
         feedingPointId: String,
         images: List<String>
-    ): ActionResult {
-        return ActionResult.Success
+    ): ActionResult<Unit> {
+        return ActionResult.Success(Unit)
     }
 
     override suspend fun updateFeedStateFlow(newFeedState: DomainFeedState) {}

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/FavouriteApiResultToActionResultMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/FavouriteApiResultToActionResultMapper.kt
@@ -4,7 +4,7 @@ import com.epmedu.animeal.common.data.wrapper.ApiResult
 import com.epmedu.animeal.common.domain.wrapper.ActionResult
 
 internal fun ApiResult<Unit>?.toActionResult() = when (this) {
-    is ApiResult.Success -> ActionResult.Success
+    is ApiResult.Success -> ActionResult.Success(Unit)
     is ApiResult.Failure -> ActionResult.Failure(error)
     else -> ActionResult.Failure(IllegalStateException("Favourite feeding point is not found"))
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/FeedingApiResultToActionResultMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/FeedingApiResultToActionResultMapper.kt
@@ -4,11 +4,11 @@ import com.epmedu.animeal.common.data.wrapper.ApiResult
 import com.epmedu.animeal.common.domain.wrapper.ActionResult
 import com.epmedu.animeal.feeding.data.error.WrongResponseError
 
-internal fun ApiResult<String>.toActionResult(feedingPointId: String): ActionResult {
+internal fun ApiResult<String>.toActionResult(feedingPointId: String): ActionResult<Unit> {
     return when (this) {
         is ApiResult.Success -> {
             when {
-                data.contains(feedingPointId) -> ActionResult.Success
+                data.contains(feedingPointId) -> ActionResult.Success(Unit)
                 else -> ActionResult.Failure(WrongResponseError())
             }
         }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FavouriteRepositoryImpl.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FavouriteRepositoryImpl.kt
@@ -67,14 +67,14 @@ internal class FavouriteRepositoryImpl(
             }
     }
 
-    override suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult {
+    override suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult<Unit> {
         return favouriteApi.addFavourite(
             feedingPointId = feedingPointId,
             userId = authApi.getCurrentUserId()
         ).toActionResult()
     }
 
-    override suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult {
+    override suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult<Unit> {
         return favourites.find { it.feedingPointId == feedingPointId }?.let { favourite ->
             favouriteApi.deleteFavourite(favourite.id)
         }.toActionResult()

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FeedingRepositoryImpl.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FeedingRepositoryImpl.kt
@@ -105,22 +105,22 @@ internal class FeedingRepositoryImpl(
         }.flowOn(dispatchers.IO)
     }
 
-    override suspend fun startFeeding(feedingPointId: String): ActionResult {
+    override suspend fun startFeeding(feedingPointId: String): ActionResult<Unit> {
         return feedingApi.startFeeding(feedingPointId).toActionResult(feedingPointId)
     }
 
-    override suspend fun cancelFeeding(feedingPointId: String): ActionResult {
+    override suspend fun cancelFeeding(feedingPointId: String): ActionResult<Unit> {
         return feedingApi.cancelFeeding(feedingPointId).toActionResult(feedingPointId)
     }
 
-    override suspend fun rejectFeeding(feedingPointId: String, reason: String): ActionResult {
+    override suspend fun rejectFeeding(feedingPointId: String, reason: String): ActionResult<Unit> {
         return feedingApi.rejectFeeding(feedingPointId, reason).toActionResult(feedingPointId)
     }
 
     override suspend fun finishFeeding(
         feedingPointId: String,
         images: List<String>
-    ): ActionResult {
+    ): ActionResult<Unit> {
         return feedingApi.finishFeeding(feedingPointId, images).toActionResult(feedingPointId)
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/repository/FavouriteRepository.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/repository/FavouriteRepository.kt
@@ -7,7 +7,7 @@ interface FavouriteRepository {
 
     fun getFavouriteFeedingPointIds(shouldFetch: Boolean = true): Flow<List<String>>
 
-    suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult
+    suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult<Unit>
 
-    suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult
+    suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult<Unit>
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/repository/FeedingRepository.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/repository/FeedingRepository.kt
@@ -15,12 +15,12 @@ interface FeedingRepository {
 
     fun getFeedingHistories(feedingPointId: String): Flow<List<FeedingHistory>>
 
-    suspend fun startFeeding(feedingPointId: String): ActionResult
+    suspend fun startFeeding(feedingPointId: String): ActionResult<Unit>
 
-    suspend fun cancelFeeding(feedingPointId: String): ActionResult
+    suspend fun cancelFeeding(feedingPointId: String): ActionResult<Unit>
 
-    suspend fun rejectFeeding(feedingPointId: String, reason: String): ActionResult
+    suspend fun rejectFeeding(feedingPointId: String, reason: String): ActionResult<Unit>
 
-    suspend fun finishFeeding(feedingPointId: String, images: List<String>): ActionResult
+    suspend fun finishFeeding(feedingPointId: String, images: List<String>): ActionResult<Unit>
     suspend fun updateFeedStateFlow(newFeedState: DomainFeedState)
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/AddFeedingPointToFavouritesUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/AddFeedingPointToFavouritesUseCase.kt
@@ -7,7 +7,7 @@ class AddFeedingPointToFavouritesUseCase(
     private val repository: FavouriteRepository
 ) {
 
-    suspend operator fun invoke(feedingPointId: String): ActionResult {
+    suspend operator fun invoke(feedingPointId: String): ActionResult<Unit> {
         return repository.addFeedingPointToFavourites(feedingPointId)
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/FinishFeedingUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/FinishFeedingUseCase.kt
@@ -9,7 +9,7 @@ class FinishFeedingUseCase @Inject constructor(private val repository: FeedingRe
     suspend operator fun invoke(
         feedingPointId: String,
         images: List<String>
-    ): ActionResult {
+    ): ActionResult<Unit> {
         return repository.finishFeeding(feedingPointId, images)
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/RemoveFeedingPointFromFavouritesUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/RemoveFeedingPointFromFavouritesUseCase.kt
@@ -7,7 +7,7 @@ class RemoveFeedingPointFromFavouritesUseCase(
     private val repository: FavouriteRepository
 ) {
 
-    suspend operator fun invoke(feedingPointId: String): ActionResult {
+    suspend operator fun invoke(feedingPointId: String): ActionResult<Unit> {
         return repository.removeFeedingPointFromFavourites(feedingPointId)
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
@@ -166,7 +166,7 @@ class DefaultFeedingHandler(
     }
 
     private suspend fun performFeedingAction(
-        action: suspend (String) -> ActionResult,
+        action: suspend (String) -> ActionResult<Unit>,
         onSuccess: suspend (FeedingPointModel) -> Unit,
         onError: () -> Unit = {}
     ) {
@@ -174,7 +174,10 @@ class DefaultFeedingHandler(
             performAction(
                 action = { action(currentFeedingPoint.id) },
                 onSuccess = { onSuccess(currentFeedingPoint) },
-                onError = ::showError
+                onError = {
+                    onError()
+                    showError()
+                }
             )
         } ?: run {
             onError()

--- a/shared/feature/networkuser/src/main/java/com/epmedu/animeal/networkuser/domain/repository/NetworkRepository.kt
+++ b/shared/feature/networkuser/src/main/java/com/epmedu/animeal/networkuser/domain/repository/NetworkRepository.kt
@@ -5,11 +5,11 @@ import com.epmedu.animeal.profile.data.model.Profile
 
 interface NetworkRepository {
 
-    suspend fun isPhoneNumberVerified(): Boolean
+    suspend fun isPhoneNumberVerified(): ActionResult<Boolean>
 
     suspend fun getNetworkProfile(): Profile?
 
-    suspend fun updateNetworkUserAttributes(profile: Profile): ActionResult
+    suspend fun updateNetworkUserAttributes(profile: Profile): ActionResult<Unit>
 
-    suspend fun deleteNetworkUser(): ActionResult
+    suspend fun deleteNetworkUser(): ActionResult<Unit>
 }


### PR DESCRIPTION
Partial implementation to EPMEDU-1923 uploaded separately to unblock other affected tickets.
- Refactored ActionResult.Success to use generics to return results.
- Fixed token expiration handling during app launches. Now user will be signed-out at SplashScreen in case their refresh token was expired.