### PR TITLE
[EPMEDU-1944] skip 0 minutes in feeding timer

### DIFF
--- a/library/extensions/src/main/java/com/epmedu/animeal/extensions/Date.kt
+++ b/library/extensions/src/main/java/com/epmedu/animeal/extensions/Date.kt
@@ -5,6 +5,7 @@ import com.epmedu.animeal.resources.R
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import kotlin.math.ceil
 
 private const val DAY_MONTH_NAME_COMMA_YEAR_FORMATTER_PATTERN = "d MMM, yyyy"
 private const val DAY_MONTH_YEAR_DOT_FORMATTER_PATTERN = "dd.MM.yyyy"
@@ -70,8 +71,8 @@ fun tryParseDate(rawDate: String?): LocalDate? {
  */
 fun Context.formatNumberToHourMin(time: Long?): String? {
     if (time == null || time < 0) return null
-    var timeInMinutes = Math.ceil(time.toDouble() / MINUTE_IN_MILLIS).toLong()
-    var hours = timeInMinutes / HOUR_IN_MINUTES
-    var minutes = timeInMinutes % HOUR_IN_MINUTES
+    val timeInMinutes = ceil(time.toDouble() / MINUTE_IN_MILLIS).toLong()
+    val hours = timeInMinutes / HOUR_IN_MINUTES
+    val minutes = timeInMinutes % HOUR_IN_MINUTES
     return "${if (hours > 0) "$hours ${getString(R.string.hours)} " else ""}$minutes ${getString(R.string.minutes)}"
 }

--- a/library/extensions/src/main/java/com/epmedu/animeal/extensions/Date.kt
+++ b/library/extensions/src/main/java/com/epmedu/animeal/extensions/Date.kt
@@ -12,6 +12,7 @@ private const val MONTH_DAY_YEAR_SLASH_FORMATTER_PATTERN = "MM/dd/yyyy"
 private const val DAY_MONTH_YEAR_SLASH_FORMATTER_PATTERN = "dd/MM/yyyy"
 const val HOUR_IN_MILLIS = 3_600_000L
 const val MINUTE_IN_MILLIS = 60_000L
+const val HOUR_IN_MINUTES = 60L
 const val SECOND_IN_MILLIS = 1_000L
 
 val DEFAULT_LOCALE: Locale
@@ -69,13 +70,8 @@ fun tryParseDate(rawDate: String?): LocalDate? {
  */
 fun Context.formatNumberToHourMin(time: Long?): String? {
     if (time == null || time < 0) return null
-    var hours = time / HOUR_IN_MILLIS
-    var minutes = time % HOUR_IN_MILLIS / MINUTE_IN_MILLIS
-    if (hours == 0L) {
-        if (minutes == 59L) {
-            hours += 1
-            minutes = 0
-        } else { minutes += 1 }
-    }
+    var timeInMinutes = Math.ceil(time.toDouble() / MINUTE_IN_MILLIS).toLong()
+    var hours = timeInMinutes / HOUR_IN_MINUTES
+    var minutes = timeInMinutes % HOUR_IN_MINUTES
     return "${if (hours > 0) "$hours ${getString(R.string.hours)} " else ""}$minutes ${getString(R.string.minutes)}"
 }

--- a/library/extensions/src/main/java/com/epmedu/animeal/extensions/Date.kt
+++ b/library/extensions/src/main/java/com/epmedu/animeal/extensions/Date.kt
@@ -69,8 +69,13 @@ fun tryParseDate(rawDate: String?): LocalDate? {
  */
 fun Context.formatNumberToHourMin(time: Long?): String? {
     if (time == null || time < 0) return null
-    val hours = time / HOUR_IN_MILLIS
-    val minutes = time % HOUR_IN_MILLIS / MINUTE_IN_MILLIS
-
+    var hours = time / HOUR_IN_MILLIS
+    var minutes = time % HOUR_IN_MILLIS / MINUTE_IN_MILLIS
+    if (hours == 0L) {
+        if (minutes == 59L) {
+            hours += 1
+            minutes = 0
+        } else { minutes += 1 }
+    }
     return "${if (hours > 0) "$hours ${getString(R.string.hours)} " else ""}$minutes ${getString(R.string.minutes)}"
 }


### PR DESCRIPTION
[EPMEDU-1944]  Fix for Incorrect time data in the timer during the feeding booking process (issue with the timer update on UI)