### PR TITLE
[EPMEDU-1179]: Draw route only if user's location is active

### DIFF
--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/event/WillFeedEvent.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/event/WillFeedEvent.kt
@@ -1,5 +1,5 @@
 package com.epmedu.animeal.feeding.presentation.event
 
 enum class WillFeedEvent {
-    WillFeedClicked, DismissWillFeed
+    WillFeedClicked, ContinueWillFeed, DismissWillFeed
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
@@ -15,6 +15,7 @@ import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.ContinueWillF
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.DismissWillFeed
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.CameraPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.ConfirmationRequested
+import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.Dismissed
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.GeolocationPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.GpsSettingRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedViewModel
@@ -31,7 +32,7 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
             viewModel.handleEvent(ContinueWillFeed)
         }
 
-    BackHandler {}
+    BackHandler(enabled = state != Dismissed) { /* Disable parent back handler */ }
 
     when (state) {
         CameraPermissionRequested -> {
@@ -65,6 +66,6 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
             )
         }
 
-        else -> {}
+        Dismissed -> {}
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
@@ -42,7 +42,7 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
         GeolocationPermissionRequested -> {
             GeolocationPermissionRequestDialog(
                 onDismiss = { viewModel.handleEvent(ContinueWillFeed) },
-                onAgree = { viewModel.handleEvent(DismissWillFeed) }
+                onConfirm = { viewModel.handleEvent(DismissWillFeed) }
             )
         }
 

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.epmedu.animeal.extensions.requestGpsByDialog
+import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.ContinueWillFeed
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.DismissWillFeed
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.CameraPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.ConfirmationRequested
@@ -27,7 +28,7 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
     val context = LocalContext.current
     val locationEmbeddedDialogLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) {
-            viewModel.handleEvent(DismissWillFeed)
+            viewModel.handleEvent(ContinueWillFeed)
         }
 
     BackHandler {}
@@ -39,7 +40,7 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
 
         GeolocationPermissionRequested -> {
             GeolocationPermissionRequestDialog(
-                onDismiss = { viewModel.handleEvent(DismissWillFeed) }
+                onDismiss = { viewModel.handleEvent(ContinueWillFeed) }
             )
         }
 

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
@@ -40,7 +40,8 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
 
         GeolocationPermissionRequested -> {
             GeolocationPermissionRequestDialog(
-                onDismiss = { viewModel.handleEvent(ContinueWillFeed) }
+                onDismiss = { viewModel.handleEvent(ContinueWillFeed) },
+                onAgree = { viewModel.handleEvent(DismissWillFeed) }
             )
         }
 

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/WillFeedDialog.kt
@@ -15,7 +15,7 @@ import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.ContinueWillF
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.DismissWillFeed
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.CameraPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.ConfirmationRequested
-import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.Dismissed
+import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.DialogDismissed
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.GeolocationPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.GpsSettingRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedViewModel
@@ -32,7 +32,7 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
             viewModel.handleEvent(ContinueWillFeed)
         }
 
-    BackHandler(enabled = state != Dismissed) { /* Disable parent back handler */ }
+    BackHandler(enabled = state != DialogDismissed) { /* Disable parent back handler */ }
 
     when (state) {
         CameraPermissionRequested -> {
@@ -66,6 +66,6 @@ fun WillFeedDialog(onAgreeClick: () -> Unit) {
             )
         }
 
-        Dismissed -> {}
+        DialogDismissed -> {}
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedState.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedState.kt
@@ -5,5 +5,5 @@ enum class WillFeedState {
     GeolocationPermissionRequested,
     GpsSettingRequested,
     ConfirmationRequested,
-    Dismissed
+    DialogDismissed
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedViewModel.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedViewModel.kt
@@ -33,8 +33,7 @@ class WillFeedViewModel @Inject constructor(
 
     fun handleEvent(event: WillFeedEvent) {
         when (event) {
-            WillFeedClicked -> checkPermissionsAndGps()
-            ContinueWillFeed -> checkPermissionsAndGps()
+            WillFeedClicked, ContinueWillFeed -> checkPermissionsAndGps()
             DismissWillFeed -> dismissWillFeed()
         }
     }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedViewModel.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.DefaultStateDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.StateDelegate
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent
+import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.ContinueWillFeed
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.DismissWillFeed
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.WillFeedClicked
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.CameraPermissionRequested
@@ -32,6 +33,7 @@ class WillFeedViewModel @Inject constructor(
     fun handleEvent(event: WillFeedEvent) {
         when (event) {
             WillFeedClicked -> checkPermissionsAndGps()
+            ContinueWillFeed -> checkPermissionsAndGps()
             DismissWillFeed -> dismissWillFeed()
         }
     }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedViewModel.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/WillFeedViewModel.kt
@@ -10,6 +10,7 @@ import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.DismissWillFe
 import com.epmedu.animeal.feeding.presentation.event.WillFeedEvent.WillFeedClicked
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.CameraPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.ConfirmationRequested
+import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.DialogDismissed
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.GeolocationPermissionRequested
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedState.GpsSettingRequested
 import com.epmedu.animeal.geolocation.gpssetting.GpsSettingState
@@ -25,7 +26,7 @@ class WillFeedViewModel @Inject constructor(
     private val permissionsHandler: PermissionsHandler,
     private val gpsSettingsProvider: GpsSettingsProvider
 ) : ViewModel(),
-    StateDelegate<WillFeedState> by DefaultStateDelegate(WillFeedState.Dismissed),
+    StateDelegate<WillFeedState> by DefaultStateDelegate(DialogDismissed),
     PermissionsHandler by permissionsHandler {
 
     private var askedToEnableGps = false
@@ -63,6 +64,6 @@ class WillFeedViewModel @Inject constructor(
     }
 
     private fun dismissWillFeed() {
-        updateState { WillFeedState.Dismissed }
+        updateState { DialogDismissed }
     }
 }

--- a/shared/feature/permissions/src/main/java/com/epmedu/animeal/permissions/presentation/ui/GeolocationPermissionRequestDialog.kt
+++ b/shared/feature/permissions/src/main/java/com/epmedu/animeal/permissions/presentation/ui/GeolocationPermissionRequestDialog.kt
@@ -10,7 +10,7 @@ import com.epmedu.animeal.resources.R
 @Composable
 fun GeolocationPermissionRequestDialog(
     onDismiss: () -> Unit,
-    onAgree: () -> Unit
+    onConfirm: () -> Unit
 ) {
     val context = LocalContext.current
 
@@ -21,7 +21,7 @@ fun GeolocationPermissionRequestDialog(
         onDismiss = onDismiss,
         onConfirm = {
             context.launchAppSettings()
-            onAgree()
+            onConfirm()
         }
     )
 }

--- a/shared/feature/permissions/src/main/java/com/epmedu/animeal/permissions/presentation/ui/GeolocationPermissionRequestDialog.kt
+++ b/shared/feature/permissions/src/main/java/com/epmedu/animeal/permissions/presentation/ui/GeolocationPermissionRequestDialog.kt
@@ -8,7 +8,10 @@ import com.epmedu.animeal.foundation.dialog.AnimealQuestionDialog
 import com.epmedu.animeal.resources.R
 
 @Composable
-fun GeolocationPermissionRequestDialog(onDismiss: () -> Unit) {
+fun GeolocationPermissionRequestDialog(
+    onDismiss: () -> Unit,
+    onAgree: () -> Unit
+) {
     val context = LocalContext.current
 
     AnimealQuestionDialog(
@@ -18,7 +21,7 @@ fun GeolocationPermissionRequestDialog(onDismiss: () -> Unit) {
         onDismiss = onDismiss,
         onConfirm = {
             context.launchAppSettings()
-            onDismiss()
+            onAgree()
         }
     )
 }


### PR DESCRIPTION
[Jira ticket](https://jira.epam.com/jira/browse/EPMEDU-1179)

- Added `ContinueWillFeed` event to make sequential checks of geolocation permission and gps setting
- Added `onAgree` callback for `GeolocationPermissionRequestDialog` to avoid showing gps setting dialog in app settings while enabling geolocation permission
- Fixed back handler in `WillFeedDialog`

P.S. Other requirements are already implemented.

| Negative flow | Positive flow |
| ------------- | ------------- |
| <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/58ed6c46-e5c1-48b2-a7bc-8444fd7cbc71"> | <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/d3c16a46-64ff-41df-9c5f-cdf8908f5e69"> |