### PR TITLE
[EPMEDU-2130]: When we press show on map link wrong map displayed

### DIFF
--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreen.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.whenCreated
+import androidx.lifecycle.withCreated
 import com.epmedu.animeal.camera.presentation.CameraView
 import com.epmedu.animeal.common.presentation.viewmodel.HomeViewModelEvent
 import com.epmedu.animeal.common.presentation.viewmodel.HomeViewModelEvent.ShowCurrentFeedingPoint
@@ -75,7 +75,7 @@ fun HomeScreen() {
     }
 
     LaunchedEffect(Unit) {
-        lifecycleOwner.whenCreated {
+        lifecycleOwner.withCreated {
             homeViewModel.handleEvents(HomeScreenEvent.ScreenDisplayed)
         }
     }

--- a/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -99,7 +99,6 @@ internal class HomeViewModel @Inject constructor(
 
     private fun onScreenDisplayed() {
         handleForcedFeedingPoint()
-        initialize()
     }
 
     private fun finishFeedingProcess() {


### PR DESCRIPTION
  - Removed redundant `initialize` call that causes the bug

| Selecting a cat after dogs were shown | Selecting a dog after cats were shown |
| ------------- | ------------- |
| <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/e819f1c4-b5e2-46df-8f58-e7571284ecf7"> | <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/7e89188a-9494-4bff-a753-55b6ce2e6570">  |