### PR TITLE
[fix/EPMEDU_2220]  Search/Favourites tabs are not reachable after feeding has started

### DIFF
--- a/feature/tabsflow/favourites/src/main/java/com/epmedu/animeal/favourites/presentation/ui/FavouritesScreenUI.kt
+++ b/feature/tabsflow/favourites/src/main/java/com/epmedu/animeal/favourites/presentation/ui/FavouritesScreenUI.kt
@@ -206,8 +206,8 @@ private fun OnFeedingConfirmationState(
     when (feedingConfirmationState) {
         FeedingStarted -> {
             navigator.navigateTo(TabsRoute.Home.name)
+            onFeedingEvent(FeedingEvent.Reset)
         }
-
         FeedingWasAlreadyBooked -> {
             AnimealAlertDialog(
                 title = stringResource(id = R.string.feeding_point_expired_description),
@@ -217,7 +217,6 @@ private fun OnFeedingConfirmationState(
                 }
             )
         }
-
         else -> {}
     }
 }

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/SearchScreenUi.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/SearchScreenUi.kt
@@ -162,6 +162,7 @@ private fun OnFeedingConfirmationState(
     when (feedingConfirmationState) {
         FeedingStarted -> {
             navigator.navigateTo(TabsRoute.Home.name)
+            onFeedingEvent(FeedingEvent.Reset)
         }
 
         FeedingWasAlreadyBooked -> {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
@@ -86,14 +86,13 @@ class DefaultFeedingHandler(
             Cancel -> cancelFeeding()
             Expired -> expireFeeding()
             is Finish -> finishFeeding(event.feedingPhotos)
-            Reset -> restartFeedingState()
+            Reset -> restartFeedingConfirmationState()
         }
     }
 
-    private fun restartFeedingState() {
+    private fun restartFeedingConfirmationState() {
         updateState {
             copy(
-                feedPoint = null,
                 feedingConfirmationState = FeedingConfirmationState.Dismissed
             )
         }


### PR DESCRIPTION
[Ticket for reference](https://jira.epam.com/jira/browse/EPMEDU-2220)

During the feeding confirmation workflow, there was a state not reached when a feeding started: after `FeedingStarted` state there was not return to `Dismissed` state. The fix and changes were added for Search and Favorites screens.

- Favorites

https://github.com/AnimealProject/animeal_android/assets/4513325/866f3104-b0ae-4f3c-bba9-9e8a05d52461

- Search

https://github.com/AnimealProject/animeal_android/assets/4513325/60586f2a-5acf-4af9-85f9-b9673155208c


