### PR TITLE
EPMEDU-2073 - Phone number is not visible due to registration process.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:theme="@android:style/Theme.Material.NoActionBar"
+        android:theme="@style/AnimealApp"
         tools:targetApi="31">
 
         <activity

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="AnimealApp" parent="@android:style/Theme.Material.NoActionBar">
+        <!-- This is required to forbid specific devices (such as Xiaomi devices) to override
+        desired modifiers while using dark mode. -->
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
Fix for systems that try to override expected modifiers while using dark mode.
Tested on Redmi Note 8 Pro.
Before:

https://github.com/AnimealProject/animeal_android/assets/112079677/293c00f1-8844-44e8-ace2-19697269dc7e

After:

https://github.com/AnimealProject/animeal_android/assets/112079677/1ca45141-f42b-4944-b656-dc47be9657d8

