### PR TITLE
Disable ad_id permission from google libraries to pass play store review process

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 
     <queries>
         <intent>
@@ -23,8 +26,8 @@
         android:name=".AnimealApplication"
         android:icon="@drawable/ic_animeal"
         android:label="@string/app_name"
-        android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:supportsRtl="true"
         android:theme="@style/AnimealApp"
         tools:targetApi="31">
 


### PR DESCRIPTION
Since our app in Play Console is configured as an app without ads, we have to remove this permission that comes from third-party libraries to avoid suspense of review process.
Reference: https://stackoverflow.com/questions/71473553/action-requested-declare-your-ad-id-permission