### PR TITLE
Fix graphQL generated models .

### DIFF
--- a/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/Feeding.java
+++ b/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/Feeding.java
@@ -1,6 +1,10 @@
 package com.amplifyframework.datastore.generated.model;
 
-import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+import com.amplifyframework.core.model.temporal.Temporal;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
 
 import androidx.core.util.ObjectsCompat;
 
@@ -8,423 +12,527 @@ import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelOperation;
 import com.amplifyframework.core.model.annotations.AuthRule;
-import com.amplifyframework.core.model.annotations.BelongsTo;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryField;
-import com.amplifyframework.core.model.temporal.Temporal;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 
 /** This is an auto generated class representing the Feeding type in your schema. */
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "Feedings", authRules = {
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
+        @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+        @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
 })
 public final class Feeding implements Model {
-  public static final QueryField ID = field("Feeding", "id");
-  public static final QueryField USER_ID = field("Feeding", "userId");
-  public static final QueryField IMAGES = field("Feeding", "images");
-  public static final QueryField STATUS = field("Feeding", "status");
-  public static final QueryField CREATED_AT = field("Feeding", "createdAt");
-  public static final QueryField UPDATED_AT = field("Feeding", "updatedAt");
-  public static final QueryField CREATED_BY = field("Feeding", "createdBy");
-  public static final QueryField UPDATED_BY = field("Feeding", "updatedBy");
-  public static final QueryField OWNER = field("Feeding", "owner");
-  public static final QueryField FEEDING_POINT = field("Feeding", "feedingPointFeedingsId");
-  public static final QueryField EXPIRE_AT = field("Feeding", "expireAt");
-  private final @ModelField(targetType="ID", isRequired = true) String id;
-  private final @ModelField(targetType="String", isRequired = true) String userId;
-  private final @ModelField(targetType="String", isRequired = true) List<String> images;
-  private final @ModelField(targetType="FeedingStatus", isRequired = true) FeedingStatus status;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime createdAt;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType="String") String createdBy;
-  private final @ModelField(targetType="String") String updatedBy;
-  private final @ModelField(targetType="String") String owner;
-  private final @ModelField(targetType="FeedingPoint", isRequired = true) @BelongsTo(targetName = "feedingPointFeedingsId", type = FeedingPoint.class) FeedingPoint feedingPoint;
-  private final @ModelField(targetType="AWSTimestamp", isRequired = true) Temporal.Timestamp expireAt;
-  public String getId() {
-      return id;
-  }
-  
-  public String getUserId() {
-      return userId;
-  }
-  
-  public List<String> getImages() {
-      return images;
-  }
-  
-  public FeedingStatus getStatus() {
-      return status;
-  }
-  
-  public Temporal.DateTime getCreatedAt() {
-      return createdAt;
-  }
-  
-  public Temporal.DateTime getUpdatedAt() {
-      return updatedAt;
-  }
-  
-  public String getCreatedBy() {
-      return createdBy;
-  }
-  
-  public String getUpdatedBy() {
-      return updatedBy;
-  }
-  
-  public String getOwner() {
-      return owner;
-  }
-  
-  public FeedingPoint getFeedingPoint() {
-      return feedingPoint;
-  }
-  
-  public Temporal.Timestamp getExpireAt() {
-      return expireAt;
-  }
-  
-  private Feeding(String id, String userId, List<String> images, FeedingStatus status, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, FeedingPoint feedingPoint, Temporal.Timestamp expireAt) {
-    this.id = id;
-    this.userId = userId;
-    this.images = images;
-    this.status = status;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-    this.createdBy = createdBy;
-    this.updatedBy = updatedBy;
-    this.owner = owner;
-    this.feedingPoint = feedingPoint;
-    this.expireAt = expireAt;
-  }
-  
-  @Override
-   public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      } else if(obj == null || getClass() != obj.getClass()) {
-        return false;
-      } else {
-      Feeding feeding = (Feeding) obj;
-      return ObjectsCompat.equals(getId(), feeding.getId()) &&
-              ObjectsCompat.equals(getUserId(), feeding.getUserId()) &&
-              ObjectsCompat.equals(getImages(), feeding.getImages()) &&
-              ObjectsCompat.equals(getStatus(), feeding.getStatus()) &&
-              ObjectsCompat.equals(getCreatedAt(), feeding.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), feeding.getUpdatedAt()) &&
-              ObjectsCompat.equals(getCreatedBy(), feeding.getCreatedBy()) &&
-              ObjectsCompat.equals(getUpdatedBy(), feeding.getUpdatedBy()) &&
-              ObjectsCompat.equals(getOwner(), feeding.getOwner()) &&
-              ObjectsCompat.equals(getFeedingPoint(), feeding.getFeedingPoint()) &&
-              ObjectsCompat.equals(getExpireAt(), feeding.getExpireAt());
-      }
-  }
-  
-  @Override
-   public int hashCode() {
-    return new StringBuilder()
-      .append(getId())
-      .append(getUserId())
-      .append(getImages())
-      .append(getStatus())
-      .append(getCreatedAt())
-      .append(getUpdatedAt())
-      .append(getCreatedBy())
-      .append(getUpdatedBy())
-      .append(getOwner())
-      .append(getFeedingPoint())
-      .append(getExpireAt())
-      .toString()
-      .hashCode();
-  }
-  
-  @Override
-   public String toString() {
-    return new StringBuilder()
-      .append("Feeding {")
-      .append("id=" + String.valueOf(getId()) + ", ")
-      .append("userId=" + String.valueOf(getUserId()) + ", ")
-      .append("images=" + String.valueOf(getImages()) + ", ")
-      .append("status=" + String.valueOf(getStatus()) + ", ")
-      .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
-      .append("updatedAt=" + String.valueOf(getUpdatedAt()) + ", ")
-      .append("createdBy=" + String.valueOf(getCreatedBy()) + ", ")
-      .append("updatedBy=" + String.valueOf(getUpdatedBy()) + ", ")
-      .append("owner=" + String.valueOf(getOwner()) + ", ")
-      .append("feedingPoint=" + String.valueOf(getFeedingPoint()) + ", ")
-      .append("expireAt=" + String.valueOf(getExpireAt()))
-      .append("}")
-      .toString();
-  }
-  
-  public static UserIdStep builder() {
-      return new Builder();
-  }
-  
-  /**
-   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
-   * This is a convenience method to return an instance of the object with only its ID populated
-   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
-   * in a relationship.
-   * @param id the id of the existing item this instance will represent
-   * @return an instance of this model with only ID populated
-   */
-  public static Feeding justId(String id) {
-    return new Feeding(
-      id,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null
-    );
-  }
-  
-  public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id,
-      userId,
-      images,
-      status,
-      createdAt,
-      updatedAt,
-      createdBy,
-      updatedBy,
-      owner,
-      feedingPoint,
-      expireAt);
-  }
-  public interface UserIdStep {
-    ImagesStep userId(String userId);
-  }
-  
+    public static final QueryField ID = field("Feeding", "id");
+    public static final QueryField USER_ID = field("Feeding", "userId");
+    public static final QueryField IMAGES = field("Feeding", "images");
+    public static final QueryField STATUS = field("Feeding", "status");
+    public static final QueryField CREATED_AT = field("Feeding", "createdAt");
+    public static final QueryField UPDATED_AT = field("Feeding", "updatedAt");
+    public static final QueryField CREATED_BY = field("Feeding", "createdBy");
+    public static final QueryField UPDATED_BY = field("Feeding", "updatedBy");
+    public static final QueryField OWNER = field("Feeding", "owner");
+    public static final QueryField FEEDING_POINT_DETAILS = field("Feeding", "feedingPointDetails");
+    public static final QueryField FEEDING_POINT_FEEDINGS_ID = field("Feeding", "feedingPointFeedingsId");
+    public static final QueryField EXPIRE_AT = field("Feeding", "expireAt");
+    public static final QueryField ASSIGNED_MODERATORS = field("Feeding", "assignedModerators");
+    public static final QueryField MODERATED_BY = field("Feeding", "moderatedBy");
+    public static final QueryField MODERATED_AT = field("Feeding", "moderatedAt");
+    private final @ModelField(targetType="ID", isRequired = true) String id;
+    private final @ModelField(targetType="String", isRequired = true) String userId;
+    private final @ModelField(targetType="String", isRequired = true) List<String> images;
+    private final @ModelField(targetType="FeedingStatus", isRequired = true) FeedingStatus status;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime createdAt;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime updatedAt;
+    private final @ModelField(targetType="String") String createdBy;
+    private final @ModelField(targetType="String") String updatedBy;
+    private final @ModelField(targetType="String") String owner;
+    private final @ModelField(targetType="FeedingPointDetails") FeedingPointDetails feedingPointDetails;
+    private final @ModelField(targetType="String", isRequired = true) String feedingPointFeedingsId;
+    private final @ModelField(targetType="AWSTimestamp", isRequired = true) Temporal.Timestamp expireAt;
+    private final @ModelField(targetType="String") List<String> assignedModerators;
+    private final @ModelField(targetType="String") String moderatedBy;
+    private final @ModelField(targetType="AWSDateTime") Temporal.DateTime moderatedAt;
+    public String getId() {
+        return id;
+    }
 
-  public interface ImagesStep {
-    StatusStep images(List<String> images);
-  }
-  
+    public String getUserId() {
+        return userId;
+    }
 
-  public interface StatusStep {
-    CreatedAtStep status(FeedingStatus status);
-  }
-  
+    public List<String> getImages() {
+        return images;
+    }
 
-  public interface CreatedAtStep {
-    UpdatedAtStep createdAt(Temporal.DateTime createdAt);
-  }
-  
+    public FeedingStatus getStatus() {
+        return status;
+    }
 
-  public interface UpdatedAtStep {
-    FeedingPointStep updatedAt(Temporal.DateTime updatedAt);
-  }
-  
+    public Temporal.DateTime getCreatedAt() {
+        return createdAt;
+    }
 
-  public interface FeedingPointStep {
-    ExpireAtStep feedingPoint(FeedingPoint feedingPoint);
-  }
-  
+    public Temporal.DateTime getUpdatedAt() {
+        return updatedAt;
+    }
 
-  public interface ExpireAtStep {
-    BuildStep expireAt(Temporal.Timestamp expireAt);
-  }
-  
+    public String getCreatedBy() {
+        return createdBy;
+    }
 
-  public interface BuildStep {
-    Feeding build();
-    BuildStep id(String id);
-    BuildStep createdBy(String createdBy);
-    BuildStep updatedBy(String updatedBy);
-    BuildStep owner(String owner);
-  }
-  
+    public String getUpdatedBy() {
+        return updatedBy;
+    }
 
-  public static class Builder implements UserIdStep, ImagesStep, StatusStep, CreatedAtStep, UpdatedAtStep, FeedingPointStep, ExpireAtStep, BuildStep {
-    private String id;
-    private String userId;
-    private List<String> images;
-    private FeedingStatus status;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
-    private FeedingPoint feedingPoint;
-    private Temporal.Timestamp expireAt;
-    private String createdBy;
-    private String updatedBy;
-    private String owner;
-    @Override
-     public Feeding build() {
-        String id = this.id != null ? this.id : UUID.randomUUID().toString();
-        
-        return new Feeding(
-          id,
-          userId,
-          images,
-          status,
-          createdAt,
-          updatedAt,
-          createdBy,
-          updatedBy,
-          owner,
-          feedingPoint,
-          expireAt);
+    public String getOwner() {
+        return owner;
     }
-    
-    @Override
-     public ImagesStep userId(String userId) {
-        Objects.requireNonNull(userId);
-        this.userId = userId;
-        return this;
+
+    public FeedingPointDetails getFeedingPointDetails() {
+        return feedingPointDetails;
     }
-    
-    @Override
-     public StatusStep images(List<String> images) {
-        Objects.requireNonNull(images);
-        this.images = images;
-        return this;
+
+    public String getFeedingPointFeedingsId() {
+        return feedingPointFeedingsId;
     }
-    
-    @Override
-     public CreatedAtStep status(FeedingStatus status) {
-        Objects.requireNonNull(status);
-        this.status = status;
-        return this;
+
+    public Temporal.Timestamp getExpireAt() {
+        return expireAt;
     }
-    
-    @Override
-     public UpdatedAtStep createdAt(Temporal.DateTime createdAt) {
-        Objects.requireNonNull(createdAt);
-        this.createdAt = createdAt;
-        return this;
+
+    public List<String> getAssignedModerators() {
+        return assignedModerators;
     }
-    
-    @Override
-     public FeedingPointStep updatedAt(Temporal.DateTime updatedAt) {
-        Objects.requireNonNull(updatedAt);
-        this.updatedAt = updatedAt;
-        return this;
+
+    public String getModeratedBy() {
+        return moderatedBy;
     }
-    
-    @Override
-     public ExpireAtStep feedingPoint(FeedingPoint feedingPoint) {
-        Objects.requireNonNull(feedingPoint);
-        this.feedingPoint = feedingPoint;
-        return this;
+
+    public Temporal.DateTime getModeratedAt() {
+        return moderatedAt;
     }
-    
-    @Override
-     public BuildStep expireAt(Temporal.Timestamp expireAt) {
-        Objects.requireNonNull(expireAt);
-        this.expireAt = expireAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdBy(String createdBy) {
-        this.createdBy = createdBy;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedBy(String updatedBy) {
-        this.updatedBy = updatedBy;
-        return this;
-    }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
-        return this;
-    }
-    
-    /**
-     * @param id id
-     * @return Current Builder instance, for fluent method chaining
-     */
-    public BuildStep id(String id) {
+
+    private Feeding(String id, String userId, List<String> images, FeedingStatus status, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, FeedingPointDetails feedingPointDetails, String feedingPointFeedingsId, Temporal.Timestamp expireAt, List<String> assignedModerators, String moderatedBy, Temporal.DateTime moderatedAt) {
         this.id = id;
-        return this;
+        this.userId = userId;
+        this.images = images;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.createdBy = createdBy;
+        this.updatedBy = updatedBy;
+        this.owner = owner;
+        this.feedingPointDetails = feedingPointDetails;
+        this.feedingPointFeedingsId = feedingPointFeedingsId;
+        this.expireAt = expireAt;
+        this.assignedModerators = assignedModerators;
+        this.moderatedBy = moderatedBy;
+        this.moderatedAt = moderatedAt;
     }
-  }
-  
 
-  public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String userId, List<String> images, FeedingStatus status, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, FeedingPoint feedingPoint, Temporal.Timestamp expireAt) {
-      super.id(id);
-      super.userId(userId)
-        .images(images)
-        .status(status)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt)
-        .feedingPoint(feedingPoint)
-        .expireAt(expireAt)
-        .createdBy(createdBy)
-        .updatedBy(updatedBy)
-        .owner(owner);
-    }
-    
     @Override
-     public CopyOfBuilder userId(String userId) {
-      return (CopyOfBuilder) super.userId(userId);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if(obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            Feeding feeding = (Feeding) obj;
+            return ObjectsCompat.equals(getId(), feeding.getId()) &&
+                    ObjectsCompat.equals(getUserId(), feeding.getUserId()) &&
+                    ObjectsCompat.equals(getImages(), feeding.getImages()) &&
+                    ObjectsCompat.equals(getStatus(), feeding.getStatus()) &&
+                    ObjectsCompat.equals(getCreatedAt(), feeding.getCreatedAt()) &&
+                    ObjectsCompat.equals(getUpdatedAt(), feeding.getUpdatedAt()) &&
+                    ObjectsCompat.equals(getCreatedBy(), feeding.getCreatedBy()) &&
+                    ObjectsCompat.equals(getUpdatedBy(), feeding.getUpdatedBy()) &&
+                    ObjectsCompat.equals(getOwner(), feeding.getOwner()) &&
+                    ObjectsCompat.equals(getFeedingPointDetails(), feeding.getFeedingPointDetails()) &&
+                    ObjectsCompat.equals(getFeedingPointFeedingsId(), feeding.getFeedingPointFeedingsId()) &&
+                    ObjectsCompat.equals(getExpireAt(), feeding.getExpireAt()) &&
+                    ObjectsCompat.equals(getAssignedModerators(), feeding.getAssignedModerators()) &&
+                    ObjectsCompat.equals(getModeratedBy(), feeding.getModeratedBy()) &&
+                    ObjectsCompat.equals(getModeratedAt(), feeding.getModeratedAt());
+        }
     }
-    
+
     @Override
-     public CopyOfBuilder images(List<String> images) {
-      return (CopyOfBuilder) super.images(images);
+    public int hashCode() {
+        return new StringBuilder()
+                .append(getId())
+                .append(getUserId())
+                .append(getImages())
+                .append(getStatus())
+                .append(getCreatedAt())
+                .append(getUpdatedAt())
+                .append(getCreatedBy())
+                .append(getUpdatedBy())
+                .append(getOwner())
+                .append(getFeedingPointDetails())
+                .append(getFeedingPointFeedingsId())
+                .append(getExpireAt())
+                .append(getAssignedModerators())
+                .append(getModeratedBy())
+                .append(getModeratedAt())
+                .toString()
+                .hashCode();
     }
-    
+
     @Override
-     public CopyOfBuilder status(FeedingStatus status) {
-      return (CopyOfBuilder) super.status(status);
+    public String toString() {
+        return new StringBuilder()
+                .append("Feeding {")
+                .append("id=" + String.valueOf(getId()) + ", ")
+                .append("userId=" + String.valueOf(getUserId()) + ", ")
+                .append("images=" + String.valueOf(getImages()) + ", ")
+                .append("status=" + String.valueOf(getStatus()) + ", ")
+                .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
+                .append("updatedAt=" + String.valueOf(getUpdatedAt()) + ", ")
+                .append("createdBy=" + String.valueOf(getCreatedBy()) + ", ")
+                .append("updatedBy=" + String.valueOf(getUpdatedBy()) + ", ")
+                .append("owner=" + String.valueOf(getOwner()) + ", ")
+                .append("feedingPointDetails=" + String.valueOf(getFeedingPointDetails()) + ", ")
+                .append("feedingPointFeedingsId=" + String.valueOf(getFeedingPointFeedingsId()) + ", ")
+                .append("expireAt=" + String.valueOf(getExpireAt()) + ", ")
+                .append("assignedModerators=" + String.valueOf(getAssignedModerators()) + ", ")
+                .append("moderatedBy=" + String.valueOf(getModeratedBy()) + ", ")
+                .append("moderatedAt=" + String.valueOf(getModeratedAt()))
+                .append("}")
+                .toString();
     }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
+
+    public static UserIdStep builder() {
+        return new Builder();
     }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
+
+    /**
+     * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+     * This is a convenience method to return an instance of the object with only its ID populated
+     * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+     * in a relationship.
+     * @param id the id of the existing item this instance will represent
+     * @return an instance of this model with only ID populated
+     */
+    public static Feeding justId(String id) {
+        return new Feeding(
+                id,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
     }
-    
-    @Override
-     public CopyOfBuilder feedingPoint(FeedingPoint feedingPoint) {
-      return (CopyOfBuilder) super.feedingPoint(feedingPoint);
+
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
+                userId,
+                images,
+                status,
+                createdAt,
+                updatedAt,
+                createdBy,
+                updatedBy,
+                owner,
+                feedingPointDetails,
+                feedingPointFeedingsId,
+                expireAt,
+                assignedModerators,
+                moderatedBy,
+                moderatedAt);
     }
-    
-    @Override
-     public CopyOfBuilder expireAt(Temporal.Timestamp expireAt) {
-      return (CopyOfBuilder) super.expireAt(expireAt);
+    public interface UserIdStep {
+        ImagesStep userId(String userId);
     }
-    
-    @Override
-     public CopyOfBuilder createdBy(String createdBy) {
-      return (CopyOfBuilder) super.createdBy(createdBy);
+
+
+    public interface ImagesStep {
+        StatusStep images(List<String> images);
     }
-    
-    @Override
-     public CopyOfBuilder updatedBy(String updatedBy) {
-      return (CopyOfBuilder) super.updatedBy(updatedBy);
+
+
+    public interface StatusStep {
+        CreatedAtStep status(FeedingStatus status);
     }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
+
+
+    public interface CreatedAtStep {
+        UpdatedAtStep createdAt(Temporal.DateTime createdAt);
     }
-  }
-  
+
+
+    public interface UpdatedAtStep {
+        FeedingPointFeedingsIdStep updatedAt(Temporal.DateTime updatedAt);
+    }
+
+
+    public interface FeedingPointFeedingsIdStep {
+        ExpireAtStep feedingPointFeedingsId(String feedingPointFeedingsId);
+    }
+
+
+    public interface ExpireAtStep {
+        BuildStep expireAt(Temporal.Timestamp expireAt);
+    }
+
+
+    public interface BuildStep {
+        Feeding build();
+        BuildStep id(String id);
+        BuildStep createdBy(String createdBy);
+        BuildStep updatedBy(String updatedBy);
+        BuildStep owner(String owner);
+        BuildStep feedingPointDetails(FeedingPointDetails feedingPointDetails);
+        BuildStep assignedModerators(List<String> assignedModerators);
+        BuildStep moderatedBy(String moderatedBy);
+        BuildStep moderatedAt(Temporal.DateTime moderatedAt);
+    }
+
+
+    public static class Builder implements UserIdStep, ImagesStep, StatusStep, CreatedAtStep, UpdatedAtStep, FeedingPointFeedingsIdStep, ExpireAtStep, BuildStep {
+        private String id;
+        private String userId;
+        private List<String> images;
+        private FeedingStatus status;
+        private Temporal.DateTime createdAt;
+        private Temporal.DateTime updatedAt;
+        private String feedingPointFeedingsId;
+        private Temporal.Timestamp expireAt;
+        private String createdBy;
+        private String updatedBy;
+        private String owner;
+        private FeedingPointDetails feedingPointDetails;
+        private List<String> assignedModerators;
+        private String moderatedBy;
+        private Temporal.DateTime moderatedAt;
+        @Override
+        public Feeding build() {
+            String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+            return new Feeding(
+                    id,
+                    userId,
+                    images,
+                    status,
+                    createdAt,
+                    updatedAt,
+                    createdBy,
+                    updatedBy,
+                    owner,
+                    feedingPointDetails,
+                    feedingPointFeedingsId,
+                    expireAt,
+                    assignedModerators,
+                    moderatedBy,
+                    moderatedAt);
+        }
+
+        @Override
+        public ImagesStep userId(String userId) {
+            Objects.requireNonNull(userId);
+            this.userId = userId;
+            return this;
+        }
+
+        @Override
+        public StatusStep images(List<String> images) {
+            Objects.requireNonNull(images);
+            this.images = images;
+            return this;
+        }
+
+        @Override
+        public CreatedAtStep status(FeedingStatus status) {
+            Objects.requireNonNull(status);
+            this.status = status;
+            return this;
+        }
+
+        @Override
+        public UpdatedAtStep createdAt(Temporal.DateTime createdAt) {
+            Objects.requireNonNull(createdAt);
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        @Override
+        public FeedingPointFeedingsIdStep updatedAt(Temporal.DateTime updatedAt) {
+            Objects.requireNonNull(updatedAt);
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        @Override
+        public ExpireAtStep feedingPointFeedingsId(String feedingPointFeedingsId) {
+            Objects.requireNonNull(feedingPointFeedingsId);
+            this.feedingPointFeedingsId = feedingPointFeedingsId;
+            return this;
+        }
+
+        @Override
+        public BuildStep expireAt(Temporal.Timestamp expireAt) {
+            Objects.requireNonNull(expireAt);
+            this.expireAt = expireAt;
+            return this;
+        }
+
+        @Override
+        public BuildStep createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep updatedBy(String updatedBy) {
+            this.updatedBy = updatedBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        @Override
+        public BuildStep feedingPointDetails(FeedingPointDetails feedingPointDetails) {
+            this.feedingPointDetails = feedingPointDetails;
+            return this;
+        }
+
+        @Override
+        public BuildStep assignedModerators(List<String> assignedModerators) {
+            this.assignedModerators = assignedModerators;
+            return this;
+        }
+
+        @Override
+        public BuildStep moderatedBy(String moderatedBy) {
+            this.moderatedBy = moderatedBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep moderatedAt(Temporal.DateTime moderatedAt) {
+            this.moderatedAt = moderatedAt;
+            return this;
+        }
+
+        /**
+         * @param id id
+         * @return Current Builder instance, for fluent method chaining
+         */
+        public BuildStep id(String id) {
+            this.id = id;
+            return this;
+        }
+    }
+
+
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String userId, List<String> images, FeedingStatus status, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, FeedingPointDetails feedingPointDetails, String feedingPointFeedingsId, Temporal.Timestamp expireAt, List<String> assignedModerators, String moderatedBy, Temporal.DateTime moderatedAt) {
+            super.id(id);
+            super.userId(userId)
+                    .images(images)
+                    .status(status)
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt)
+                    .feedingPointFeedingsId(feedingPointFeedingsId)
+                    .expireAt(expireAt)
+                    .createdBy(createdBy)
+                    .updatedBy(updatedBy)
+                    .owner(owner)
+                    .feedingPointDetails(feedingPointDetails)
+                    .assignedModerators(assignedModerators)
+                    .moderatedBy(moderatedBy)
+                    .moderatedAt(moderatedAt);
+        }
+
+        @Override
+        public CopyOfBuilder userId(String userId) {
+            return (CopyOfBuilder) super.userId(userId);
+        }
+
+        @Override
+        public CopyOfBuilder images(List<String> images) {
+            return (CopyOfBuilder) super.images(images);
+        }
+
+        @Override
+        public CopyOfBuilder status(FeedingStatus status) {
+            return (CopyOfBuilder) super.status(status);
+        }
+
+        @Override
+        public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+            return (CopyOfBuilder) super.createdAt(createdAt);
+        }
+
+        @Override
+        public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+            return (CopyOfBuilder) super.updatedAt(updatedAt);
+        }
+
+        @Override
+        public CopyOfBuilder feedingPointFeedingsId(String feedingPointFeedingsId) {
+            return (CopyOfBuilder) super.feedingPointFeedingsId(feedingPointFeedingsId);
+        }
+
+        @Override
+        public CopyOfBuilder expireAt(Temporal.Timestamp expireAt) {
+            return (CopyOfBuilder) super.expireAt(expireAt);
+        }
+
+        @Override
+        public CopyOfBuilder createdBy(String createdBy) {
+            return (CopyOfBuilder) super.createdBy(createdBy);
+        }
+
+        @Override
+        public CopyOfBuilder updatedBy(String updatedBy) {
+            return (CopyOfBuilder) super.updatedBy(updatedBy);
+        }
+
+        @Override
+        public CopyOfBuilder owner(String owner) {
+            return (CopyOfBuilder) super.owner(owner);
+        }
+
+        @Override
+        public CopyOfBuilder feedingPointDetails(FeedingPointDetails feedingPointDetails) {
+            return (CopyOfBuilder) super.feedingPointDetails(feedingPointDetails);
+        }
+
+        @Override
+        public CopyOfBuilder assignedModerators(List<String> assignedModerators) {
+            return (CopyOfBuilder) super.assignedModerators(assignedModerators);
+        }
+
+        @Override
+        public CopyOfBuilder moderatedBy(String moderatedBy) {
+            return (CopyOfBuilder) super.moderatedBy(moderatedBy);
+        }
+
+        @Override
+        public CopyOfBuilder moderatedAt(Temporal.DateTime moderatedAt) {
+            return (CopyOfBuilder) super.moderatedAt(moderatedAt);
+        }
+    }
+
 }

--- a/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingHistory.java
+++ b/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingHistory.java
@@ -1,6 +1,10 @@
 package com.amplifyframework.datastore.generated.model;
 
-import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+import com.amplifyframework.core.model.temporal.Temporal;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
 
 import androidx.core.util.ObjectsCompat;
 
@@ -11,409 +15,514 @@ import com.amplifyframework.core.model.annotations.AuthRule;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryField;
-import com.amplifyframework.core.model.temporal.Temporal;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 
 /** This is an auto generated class representing the FeedingHistory type in your schema. */
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "FeedingHistories", authRules = {
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
+        @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+        @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
 })
 public final class FeedingHistory implements Model {
-  public static final QueryField ID = field("FeedingHistory", "id");
-  public static final QueryField USER_ID = field("FeedingHistory", "userId");
-  public static final QueryField IMAGES = field("FeedingHistory", "images");
-  public static final QueryField CREATED_AT = field("FeedingHistory", "createdAt");
-  public static final QueryField UPDATED_AT = field("FeedingHistory", "updatedAt");
-  public static final QueryField CREATED_BY = field("FeedingHistory", "createdBy");
-  public static final QueryField UPDATED_BY = field("FeedingHistory", "updatedBy");
-  public static final QueryField OWNER = field("FeedingHistory", "owner");
-  public static final QueryField FEEDING_POINT_ID = field("FeedingHistory", "feedingPointId");
-  public static final QueryField STATUS = field("FeedingHistory", "status");
-  public static final QueryField REASON = field("FeedingHistory", "reason");
-  private final @ModelField(targetType="ID", isRequired = true) String id;
-  private final @ModelField(targetType="String", isRequired = true) String userId;
-  private final @ModelField(targetType="String", isRequired = true) List<String> images;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime createdAt;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType="String") String createdBy;
-  private final @ModelField(targetType="String") String updatedBy;
-  private final @ModelField(targetType="String") String owner;
-  private final @ModelField(targetType="String", isRequired = true) String feedingPointId;
-  private final @ModelField(targetType="FeedingStatus") FeedingStatus status;
-  private final @ModelField(targetType="String") String reason;
-  public String getId() {
-      return id;
-  }
-  
-  public String getUserId() {
-      return userId;
-  }
-  
-  public List<String> getImages() {
-      return images;
-  }
-  
-  public Temporal.DateTime getCreatedAt() {
-      return createdAt;
-  }
-  
-  public Temporal.DateTime getUpdatedAt() {
-      return updatedAt;
-  }
-  
-  public String getCreatedBy() {
-      return createdBy;
-  }
-  
-  public String getUpdatedBy() {
-      return updatedBy;
-  }
-  
-  public String getOwner() {
-      return owner;
-  }
-  
-  public String getFeedingPointId() {
-      return feedingPointId;
-  }
-  
-  public FeedingStatus getStatus() {
-      return status;
-  }
-  
-  public String getReason() {
-      return reason;
-  }
-  
-  private FeedingHistory(String id, String userId, List<String> images, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String feedingPointId, FeedingStatus status, String reason) {
-    this.id = id;
-    this.userId = userId;
-    this.images = images;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-    this.createdBy = createdBy;
-    this.updatedBy = updatedBy;
-    this.owner = owner;
-    this.feedingPointId = feedingPointId;
-    this.status = status;
-    this.reason = reason;
-  }
-  
-  @Override
-   public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      } else if(obj == null || getClass() != obj.getClass()) {
-        return false;
-      } else {
-      FeedingHistory feedingHistory = (FeedingHistory) obj;
-      return ObjectsCompat.equals(getId(), feedingHistory.getId()) &&
-              ObjectsCompat.equals(getUserId(), feedingHistory.getUserId()) &&
-              ObjectsCompat.equals(getImages(), feedingHistory.getImages()) &&
-              ObjectsCompat.equals(getCreatedAt(), feedingHistory.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), feedingHistory.getUpdatedAt()) &&
-              ObjectsCompat.equals(getCreatedBy(), feedingHistory.getCreatedBy()) &&
-              ObjectsCompat.equals(getUpdatedBy(), feedingHistory.getUpdatedBy()) &&
-              ObjectsCompat.equals(getOwner(), feedingHistory.getOwner()) &&
-              ObjectsCompat.equals(getFeedingPointId(), feedingHistory.getFeedingPointId()) &&
-              ObjectsCompat.equals(getStatus(), feedingHistory.getStatus()) &&
-              ObjectsCompat.equals(getReason(), feedingHistory.getReason());
-      }
-  }
-  
-  @Override
-   public int hashCode() {
-    return new StringBuilder()
-      .append(getId())
-      .append(getUserId())
-      .append(getImages())
-      .append(getCreatedAt())
-      .append(getUpdatedAt())
-      .append(getCreatedBy())
-      .append(getUpdatedBy())
-      .append(getOwner())
-      .append(getFeedingPointId())
-      .append(getStatus())
-      .append(getReason())
-      .toString()
-      .hashCode();
-  }
-  
-  @Override
-   public String toString() {
-    return new StringBuilder()
-      .append("FeedingHistory {")
-      .append("id=" + String.valueOf(getId()) + ", ")
-      .append("userId=" + String.valueOf(getUserId()) + ", ")
-      .append("images=" + String.valueOf(getImages()) + ", ")
-      .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
-      .append("updatedAt=" + String.valueOf(getUpdatedAt()) + ", ")
-      .append("createdBy=" + String.valueOf(getCreatedBy()) + ", ")
-      .append("updatedBy=" + String.valueOf(getUpdatedBy()) + ", ")
-      .append("owner=" + String.valueOf(getOwner()) + ", ")
-      .append("feedingPointId=" + String.valueOf(getFeedingPointId()) + ", ")
-      .append("status=" + String.valueOf(getStatus()) + ", ")
-      .append("reason=" + String.valueOf(getReason()))
-      .append("}")
-      .toString();
-  }
-  
-  public static UserIdStep builder() {
-      return new Builder();
-  }
-  
-  /**
-   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
-   * This is a convenience method to return an instance of the object with only its ID populated
-   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
-   * in a relationship.
-   * @param id the id of the existing item this instance will represent
-   * @return an instance of this model with only ID populated
-   */
-  public static FeedingHistory justId(String id) {
-    return new FeedingHistory(
-      id,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null
-    );
-  }
-  
-  public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id,
-      userId,
-      images,
-      createdAt,
-      updatedAt,
-      createdBy,
-      updatedBy,
-      owner,
-      feedingPointId,
-      status,
-      reason);
-  }
-  public interface UserIdStep {
-    ImagesStep userId(String userId);
-  }
-  
+    public static final QueryField ID = field("FeedingHistory", "id");
+    public static final QueryField USER_ID = field("FeedingHistory", "userId");
+    public static final QueryField IMAGES = field("FeedingHistory", "images");
+    public static final QueryField CREATED_AT = field("FeedingHistory", "createdAt");
+    public static final QueryField UPDATED_AT = field("FeedingHistory", "updatedAt");
+    public static final QueryField CREATED_BY = field("FeedingHistory", "createdBy");
+    public static final QueryField UPDATED_BY = field("FeedingHistory", "updatedBy");
+    public static final QueryField OWNER = field("FeedingHistory", "owner");
+    public static final QueryField FEEDING_POINT_ID = field("FeedingHistory", "feedingPointId");
+    public static final QueryField FEEDING_POINT_DETAILS = field("FeedingHistory", "feedingPointDetails");
+    public static final QueryField STATUS = field("FeedingHistory", "status");
+    public static final QueryField REASON = field("FeedingHistory", "reason");
+    public static final QueryField MODERATED_BY = field("FeedingHistory", "moderatedBy");
+    public static final QueryField MODERATED_AT = field("FeedingHistory", "moderatedAt");
+    public static final QueryField ASSIGNED_MODERATORS = field("FeedingHistory", "assignedModerators");
+    private final @ModelField(targetType="ID", isRequired = true) String id;
+    private final @ModelField(targetType="String", isRequired = true) String userId;
+    private final @ModelField(targetType="String", isRequired = true) List<String> images;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime createdAt;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime updatedAt;
+    private final @ModelField(targetType="String") String createdBy;
+    private final @ModelField(targetType="String") String updatedBy;
+    private final @ModelField(targetType="String") String owner;
+    private final @ModelField(targetType="String", isRequired = true) String feedingPointId;
+    private final @ModelField(targetType="FeedingPointDetails") FeedingPointDetails feedingPointDetails;
+    private final @ModelField(targetType="FeedingStatus") FeedingStatus status;
+    private final @ModelField(targetType="String") String reason;
+    private final @ModelField(targetType="String") String moderatedBy;
+    private final @ModelField(targetType="AWSDateTime") Temporal.DateTime moderatedAt;
+    private final @ModelField(targetType="String") List<String> assignedModerators;
+    public String getId() {
+        return id;
+    }
 
-  public interface ImagesStep {
-    CreatedAtStep images(List<String> images);
-  }
-  
+    public String getUserId() {
+        return userId;
+    }
 
-  public interface CreatedAtStep {
-    UpdatedAtStep createdAt(Temporal.DateTime createdAt);
-  }
-  
+    public List<String> getImages() {
+        return images;
+    }
 
-  public interface UpdatedAtStep {
-    FeedingPointIdStep updatedAt(Temporal.DateTime updatedAt);
-  }
-  
+    public Temporal.DateTime getCreatedAt() {
+        return createdAt;
+    }
 
-  public interface FeedingPointIdStep {
-    BuildStep feedingPointId(String feedingPointId);
-  }
-  
+    public Temporal.DateTime getUpdatedAt() {
+        return updatedAt;
+    }
 
-  public interface BuildStep {
-    FeedingHistory build();
-    BuildStep id(String id);
-    BuildStep createdBy(String createdBy);
-    BuildStep updatedBy(String updatedBy);
-    BuildStep owner(String owner);
-    BuildStep status(FeedingStatus status);
-    BuildStep reason(String reason);
-  }
-  
+    public String getCreatedBy() {
+        return createdBy;
+    }
 
-  public static class Builder implements UserIdStep, ImagesStep, CreatedAtStep, UpdatedAtStep, FeedingPointIdStep, BuildStep {
-    private String id;
-    private String userId;
-    private List<String> images;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
-    private String feedingPointId;
-    private String createdBy;
-    private String updatedBy;
-    private String owner;
-    private FeedingStatus status;
-    private String reason;
-    @Override
-     public FeedingHistory build() {
-        String id = this.id != null ? this.id : UUID.randomUUID().toString();
-        
-        return new FeedingHistory(
-          id,
-          userId,
-          images,
-          createdAt,
-          updatedAt,
-          createdBy,
-          updatedBy,
-          owner,
-          feedingPointId,
-          status,
-          reason);
+    public String getUpdatedBy() {
+        return updatedBy;
     }
-    
-    @Override
-     public ImagesStep userId(String userId) {
-        Objects.requireNonNull(userId);
-        this.userId = userId;
-        return this;
+
+    public String getOwner() {
+        return owner;
     }
-    
-    @Override
-     public CreatedAtStep images(List<String> images) {
-        Objects.requireNonNull(images);
-        this.images = images;
-        return this;
+
+    public String getFeedingPointId() {
+        return feedingPointId;
     }
-    
-    @Override
-     public UpdatedAtStep createdAt(Temporal.DateTime createdAt) {
-        Objects.requireNonNull(createdAt);
-        this.createdAt = createdAt;
-        return this;
+
+    public FeedingPointDetails getFeedingPointDetails() {
+        return feedingPointDetails;
     }
-    
-    @Override
-     public FeedingPointIdStep updatedAt(Temporal.DateTime updatedAt) {
-        Objects.requireNonNull(updatedAt);
-        this.updatedAt = updatedAt;
-        return this;
+
+    public FeedingStatus getStatus() {
+        return status;
     }
-    
-    @Override
-     public BuildStep feedingPointId(String feedingPointId) {
-        Objects.requireNonNull(feedingPointId);
-        this.feedingPointId = feedingPointId;
-        return this;
+
+    public String getReason() {
+        return reason;
     }
-    
-    @Override
-     public BuildStep createdBy(String createdBy) {
-        this.createdBy = createdBy;
-        return this;
+
+    public String getModeratedBy() {
+        return moderatedBy;
     }
-    
-    @Override
-     public BuildStep updatedBy(String updatedBy) {
-        this.updatedBy = updatedBy;
-        return this;
+
+    public Temporal.DateTime getModeratedAt() {
+        return moderatedAt;
     }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
-        return this;
+
+    public List<String> getAssignedModerators() {
+        return assignedModerators;
     }
-    
-    @Override
-     public BuildStep status(FeedingStatus status) {
-        this.status = status;
-        return this;
-    }
-    
-    @Override
-     public BuildStep reason(String reason) {
-        this.reason = reason;
-        return this;
-    }
-    
-    /**
-     * @param id id
-     * @return Current Builder instance, for fluent method chaining
-     */
-    public BuildStep id(String id) {
+
+    private FeedingHistory(String id, String userId, List<String> images, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String feedingPointId, FeedingPointDetails feedingPointDetails, FeedingStatus status, String reason, String moderatedBy, Temporal.DateTime moderatedAt, List<String> assignedModerators) {
         this.id = id;
-        return this;
+        this.userId = userId;
+        this.images = images;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.createdBy = createdBy;
+        this.updatedBy = updatedBy;
+        this.owner = owner;
+        this.feedingPointId = feedingPointId;
+        this.feedingPointDetails = feedingPointDetails;
+        this.status = status;
+        this.reason = reason;
+        this.moderatedBy = moderatedBy;
+        this.moderatedAt = moderatedAt;
+        this.assignedModerators = assignedModerators;
     }
-  }
-  
 
-  public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String userId, List<String> images, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String feedingPointId, FeedingStatus status, String reason) {
-      super.id(id);
-      super.userId(userId)
-        .images(images)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt)
-        .feedingPointId(feedingPointId)
-        .createdBy(createdBy)
-        .updatedBy(updatedBy)
-        .owner(owner)
-        .status(status)
-        .reason(reason);
-    }
-    
     @Override
-     public CopyOfBuilder userId(String userId) {
-      return (CopyOfBuilder) super.userId(userId);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if(obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            FeedingHistory feedingHistory = (FeedingHistory) obj;
+            return ObjectsCompat.equals(getId(), feedingHistory.getId()) &&
+                    ObjectsCompat.equals(getUserId(), feedingHistory.getUserId()) &&
+                    ObjectsCompat.equals(getImages(), feedingHistory.getImages()) &&
+                    ObjectsCompat.equals(getCreatedAt(), feedingHistory.getCreatedAt()) &&
+                    ObjectsCompat.equals(getUpdatedAt(), feedingHistory.getUpdatedAt()) &&
+                    ObjectsCompat.equals(getCreatedBy(), feedingHistory.getCreatedBy()) &&
+                    ObjectsCompat.equals(getUpdatedBy(), feedingHistory.getUpdatedBy()) &&
+                    ObjectsCompat.equals(getOwner(), feedingHistory.getOwner()) &&
+                    ObjectsCompat.equals(getFeedingPointId(), feedingHistory.getFeedingPointId()) &&
+                    ObjectsCompat.equals(getFeedingPointDetails(), feedingHistory.getFeedingPointDetails()) &&
+                    ObjectsCompat.equals(getStatus(), feedingHistory.getStatus()) &&
+                    ObjectsCompat.equals(getReason(), feedingHistory.getReason()) &&
+                    ObjectsCompat.equals(getModeratedBy(), feedingHistory.getModeratedBy()) &&
+                    ObjectsCompat.equals(getModeratedAt(), feedingHistory.getModeratedAt()) &&
+                    ObjectsCompat.equals(getAssignedModerators(), feedingHistory.getAssignedModerators());
+        }
     }
-    
+
     @Override
-     public CopyOfBuilder images(List<String> images) {
-      return (CopyOfBuilder) super.images(images);
+    public int hashCode() {
+        return new StringBuilder()
+                .append(getId())
+                .append(getUserId())
+                .append(getImages())
+                .append(getCreatedAt())
+                .append(getUpdatedAt())
+                .append(getCreatedBy())
+                .append(getUpdatedBy())
+                .append(getOwner())
+                .append(getFeedingPointId())
+                .append(getFeedingPointDetails())
+                .append(getStatus())
+                .append(getReason())
+                .append(getModeratedBy())
+                .append(getModeratedAt())
+                .append(getAssignedModerators())
+                .toString()
+                .hashCode();
     }
-    
+
     @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
+    public String toString() {
+        return new StringBuilder()
+                .append("FeedingHistory {")
+                .append("id=" + String.valueOf(getId()) + ", ")
+                .append("userId=" + String.valueOf(getUserId()) + ", ")
+                .append("images=" + String.valueOf(getImages()) + ", ")
+                .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
+                .append("updatedAt=" + String.valueOf(getUpdatedAt()) + ", ")
+                .append("createdBy=" + String.valueOf(getCreatedBy()) + ", ")
+                .append("updatedBy=" + String.valueOf(getUpdatedBy()) + ", ")
+                .append("owner=" + String.valueOf(getOwner()) + ", ")
+                .append("feedingPointId=" + String.valueOf(getFeedingPointId()) + ", ")
+                .append("feedingPointDetails=" + String.valueOf(getFeedingPointDetails()) + ", ")
+                .append("status=" + String.valueOf(getStatus()) + ", ")
+                .append("reason=" + String.valueOf(getReason()) + ", ")
+                .append("moderatedBy=" + String.valueOf(getModeratedBy()) + ", ")
+                .append("moderatedAt=" + String.valueOf(getModeratedAt()) + ", ")
+                .append("assignedModerators=" + String.valueOf(getAssignedModerators()))
+                .append("}")
+                .toString();
     }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
+
+    public static UserIdStep builder() {
+        return new Builder();
     }
-    
-    @Override
-     public CopyOfBuilder feedingPointId(String feedingPointId) {
-      return (CopyOfBuilder) super.feedingPointId(feedingPointId);
+
+    /**
+     * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+     * This is a convenience method to return an instance of the object with only its ID populated
+     * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+     * in a relationship.
+     * @param id the id of the existing item this instance will represent
+     * @return an instance of this model with only ID populated
+     */
+    public static FeedingHistory justId(String id) {
+        return new FeedingHistory(
+                id,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
     }
-    
-    @Override
-     public CopyOfBuilder createdBy(String createdBy) {
-      return (CopyOfBuilder) super.createdBy(createdBy);
+
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
+                userId,
+                images,
+                createdAt,
+                updatedAt,
+                createdBy,
+                updatedBy,
+                owner,
+                feedingPointId,
+                feedingPointDetails,
+                status,
+                reason,
+                moderatedBy,
+                moderatedAt,
+                assignedModerators);
     }
-    
-    @Override
-     public CopyOfBuilder updatedBy(String updatedBy) {
-      return (CopyOfBuilder) super.updatedBy(updatedBy);
+    public interface UserIdStep {
+        ImagesStep userId(String userId);
     }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
+
+
+    public interface ImagesStep {
+        CreatedAtStep images(List<String> images);
     }
-    
-    @Override
-     public CopyOfBuilder status(FeedingStatus status) {
-      return (CopyOfBuilder) super.status(status);
+
+
+    public interface CreatedAtStep {
+        UpdatedAtStep createdAt(Temporal.DateTime createdAt);
     }
-    
-    @Override
-     public CopyOfBuilder reason(String reason) {
-      return (CopyOfBuilder) super.reason(reason);
+
+
+    public interface UpdatedAtStep {
+        FeedingPointIdStep updatedAt(Temporal.DateTime updatedAt);
     }
-  }
-  
+
+
+    public interface FeedingPointIdStep {
+        BuildStep feedingPointId(String feedingPointId);
+    }
+
+
+    public interface BuildStep {
+        FeedingHistory build();
+        BuildStep id(String id);
+        BuildStep createdBy(String createdBy);
+        BuildStep updatedBy(String updatedBy);
+        BuildStep owner(String owner);
+        BuildStep feedingPointDetails(FeedingPointDetails feedingPointDetails);
+        BuildStep status(FeedingStatus status);
+        BuildStep reason(String reason);
+        BuildStep moderatedBy(String moderatedBy);
+        BuildStep moderatedAt(Temporal.DateTime moderatedAt);
+        BuildStep assignedModerators(List<String> assignedModerators);
+    }
+
+
+    public static class Builder implements UserIdStep, ImagesStep, CreatedAtStep, UpdatedAtStep, FeedingPointIdStep, BuildStep {
+        private String id;
+        private String userId;
+        private List<String> images;
+        private Temporal.DateTime createdAt;
+        private Temporal.DateTime updatedAt;
+        private String feedingPointId;
+        private String createdBy;
+        private String updatedBy;
+        private String owner;
+        private FeedingPointDetails feedingPointDetails;
+        private FeedingStatus status;
+        private String reason;
+        private String moderatedBy;
+        private Temporal.DateTime moderatedAt;
+        private List<String> assignedModerators;
+        @Override
+        public FeedingHistory build() {
+            String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+            return new FeedingHistory(
+                    id,
+                    userId,
+                    images,
+                    createdAt,
+                    updatedAt,
+                    createdBy,
+                    updatedBy,
+                    owner,
+                    feedingPointId,
+                    feedingPointDetails,
+                    status,
+                    reason,
+                    moderatedBy,
+                    moderatedAt,
+                    assignedModerators);
+        }
+
+        @Override
+        public ImagesStep userId(String userId) {
+            Objects.requireNonNull(userId);
+            this.userId = userId;
+            return this;
+        }
+
+        @Override
+        public CreatedAtStep images(List<String> images) {
+            Objects.requireNonNull(images);
+            this.images = images;
+            return this;
+        }
+
+        @Override
+        public UpdatedAtStep createdAt(Temporal.DateTime createdAt) {
+            Objects.requireNonNull(createdAt);
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        @Override
+        public FeedingPointIdStep updatedAt(Temporal.DateTime updatedAt) {
+            Objects.requireNonNull(updatedAt);
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        @Override
+        public BuildStep feedingPointId(String feedingPointId) {
+            Objects.requireNonNull(feedingPointId);
+            this.feedingPointId = feedingPointId;
+            return this;
+        }
+
+        @Override
+        public BuildStep createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep updatedBy(String updatedBy) {
+            this.updatedBy = updatedBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        @Override
+        public BuildStep feedingPointDetails(FeedingPointDetails feedingPointDetails) {
+            this.feedingPointDetails = feedingPointDetails;
+            return this;
+        }
+
+        @Override
+        public BuildStep status(FeedingStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        @Override
+        public BuildStep reason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        @Override
+        public BuildStep moderatedBy(String moderatedBy) {
+            this.moderatedBy = moderatedBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep moderatedAt(Temporal.DateTime moderatedAt) {
+            this.moderatedAt = moderatedAt;
+            return this;
+        }
+
+        @Override
+        public BuildStep assignedModerators(List<String> assignedModerators) {
+            this.assignedModerators = assignedModerators;
+            return this;
+        }
+
+        /**
+         * @param id id
+         * @return Current Builder instance, for fluent method chaining
+         */
+        public BuildStep id(String id) {
+            this.id = id;
+            return this;
+        }
+    }
+
+
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String userId, List<String> images, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String feedingPointId, FeedingPointDetails feedingPointDetails, FeedingStatus status, String reason, String moderatedBy, Temporal.DateTime moderatedAt, List<String> assignedModerators) {
+            super.id(id);
+            super.userId(userId)
+                    .images(images)
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt)
+                    .feedingPointId(feedingPointId)
+                    .createdBy(createdBy)
+                    .updatedBy(updatedBy)
+                    .owner(owner)
+                    .feedingPointDetails(feedingPointDetails)
+                    .status(status)
+                    .reason(reason)
+                    .moderatedBy(moderatedBy)
+                    .moderatedAt(moderatedAt)
+                    .assignedModerators(assignedModerators);
+        }
+
+        @Override
+        public CopyOfBuilder userId(String userId) {
+            return (CopyOfBuilder) super.userId(userId);
+        }
+
+        @Override
+        public CopyOfBuilder images(List<String> images) {
+            return (CopyOfBuilder) super.images(images);
+        }
+
+        @Override
+        public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+            return (CopyOfBuilder) super.createdAt(createdAt);
+        }
+
+        @Override
+        public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+            return (CopyOfBuilder) super.updatedAt(updatedAt);
+        }
+
+        @Override
+        public CopyOfBuilder feedingPointId(String feedingPointId) {
+            return (CopyOfBuilder) super.feedingPointId(feedingPointId);
+        }
+
+        @Override
+        public CopyOfBuilder createdBy(String createdBy) {
+            return (CopyOfBuilder) super.createdBy(createdBy);
+        }
+
+        @Override
+        public CopyOfBuilder updatedBy(String updatedBy) {
+            return (CopyOfBuilder) super.updatedBy(updatedBy);
+        }
+
+        @Override
+        public CopyOfBuilder owner(String owner) {
+            return (CopyOfBuilder) super.owner(owner);
+        }
+
+        @Override
+        public CopyOfBuilder feedingPointDetails(FeedingPointDetails feedingPointDetails) {
+            return (CopyOfBuilder) super.feedingPointDetails(feedingPointDetails);
+        }
+
+        @Override
+        public CopyOfBuilder status(FeedingStatus status) {
+            return (CopyOfBuilder) super.status(status);
+        }
+
+        @Override
+        public CopyOfBuilder reason(String reason) {
+            return (CopyOfBuilder) super.reason(reason);
+        }
+
+        @Override
+        public CopyOfBuilder moderatedBy(String moderatedBy) {
+            return (CopyOfBuilder) super.moderatedBy(moderatedBy);
+        }
+
+        @Override
+        public CopyOfBuilder moderatedAt(Temporal.DateTime moderatedAt) {
+            return (CopyOfBuilder) super.moderatedAt(moderatedAt);
+        }
+
+        @Override
+        public CopyOfBuilder assignedModerators(List<String> assignedModerators) {
+            return (CopyOfBuilder) super.assignedModerators(assignedModerators);
+        }
+    }
+
 }

--- a/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingPoint.java
+++ b/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingPoint.java
@@ -1,6 +1,12 @@
 package com.amplifyframework.datastore.generated.model;
 
-import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.core.model.annotations.HasMany;
+import com.amplifyframework.core.model.annotations.HasOne;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
 
 import androidx.core.util.ObjectsCompat;
 
@@ -8,776 +14,766 @@ import com.amplifyframework.core.model.AuthStrategy;
 import com.amplifyframework.core.model.Model;
 import com.amplifyframework.core.model.ModelOperation;
 import com.amplifyframework.core.model.annotations.AuthRule;
-import com.amplifyframework.core.model.annotations.HasMany;
-import com.amplifyframework.core.model.annotations.HasOne;
 import com.amplifyframework.core.model.annotations.ModelConfig;
 import com.amplifyframework.core.model.annotations.ModelField;
 import com.amplifyframework.core.model.query.predicate.QueryField;
-import com.amplifyframework.core.model.temporal.Temporal;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 
 /** This is an auto generated class representing the FeedingPoint type in your schema. */
 @SuppressWarnings("all")
 @ModelConfig(pluralName = "FeedingPoints", authRules = {
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
-  @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
+        @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+        @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+        @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
 })
 public final class FeedingPoint implements Model {
-  public static final QueryField ID = field("FeedingPoint", "id");
-  public static final QueryField NAME = field("FeedingPoint", "name");
-  public static final QueryField DESCRIPTION = field("FeedingPoint", "description");
-  public static final QueryField CITY = field("FeedingPoint", "city");
-  public static final QueryField STREET = field("FeedingPoint", "street");
-  public static final QueryField ADDRESS = field("FeedingPoint", "address");
-  public static final QueryField IMAGES = field("FeedingPoint", "images");
-  public static final QueryField POINT = field("FeedingPoint", "point");
-  public static final QueryField LOCATION = field("FeedingPoint", "location");
-  public static final QueryField REGION = field("FeedingPoint", "region");
-  public static final QueryField NEIGHBORHOOD = field("FeedingPoint", "neighborhood");
-  public static final QueryField DISTANCE = field("FeedingPoint", "distance");
-  public static final QueryField STATUS = field("FeedingPoint", "status");
-  public static final QueryField I18N = field("FeedingPoint", "i18n");
-  public static final QueryField STATUS_UPDATED_AT = field("FeedingPoint", "statusUpdatedAt");
-  public static final QueryField CREATED_AT = field("FeedingPoint", "createdAt");
-  public static final QueryField UPDATED_AT = field("FeedingPoint", "updatedAt");
-  public static final QueryField CREATED_BY = field("FeedingPoint", "createdBy");
-  public static final QueryField UPDATED_BY = field("FeedingPoint", "updatedBy");
-  public static final QueryField OWNER = field("FeedingPoint", "owner");
-  public static final QueryField COVER = field("FeedingPoint", "cover");
-  public static final QueryField FEEDING_POINT_CATEGORY_ID = field("FeedingPoint", "feedingPointCategoryId");
-  private final @ModelField(targetType="ID", isRequired = true) String id;
-  private final @ModelField(targetType="String", isRequired = true) String name;
-  private final @ModelField(targetType="String", isRequired = true) String description;
-  private final @ModelField(targetType="String", isRequired = true) String city;
-  private final @ModelField(targetType="String", isRequired = true) String street;
-  private final @ModelField(targetType="String", isRequired = true) String address;
-  private final @ModelField(targetType="String") List<String> images;
-  private final @ModelField(targetType="Point", isRequired = true) Point point;
-  private final @ModelField(targetType="Location", isRequired = true) Location location;
-  private final @ModelField(targetType="String", isRequired = true) String region;
-  private final @ModelField(targetType="String", isRequired = true) String neighborhood;
-  private final @ModelField(targetType="Float", isRequired = true) Double distance;
-  private final @ModelField(targetType="FeedingPointStatus", isRequired = true) FeedingPointStatus status;
-  private final @ModelField(targetType="FeedingPointI18n") List<FeedingPointI18n> i18n;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime statusUpdatedAt;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime createdAt;
-  private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType="String") String createdBy;
-  private final @ModelField(targetType="String") String updatedBy;
-  private final @ModelField(targetType="String") String owner;
-  private final @ModelField(targetType="RelationPetFeedingPoint") @HasMany(associatedWith = "feedingPoint", type = RelationPetFeedingPoint.class) List<RelationPetFeedingPoint> pets = null;
-  private final @ModelField(targetType="Category") @HasOne(associatedWith = "id", type = Category.class) Category category = null;
-  private final @ModelField(targetType="RelationUserFeedingPoint") @HasMany(associatedWith = "feedingPoint", type = RelationUserFeedingPoint.class) List<RelationUserFeedingPoint> users = null;
-  private final @ModelField(targetType="Feeding") @HasMany(associatedWith = "feedingPoint", type = Feeding.class) List<Feeding> feedings = null;
-  private final @ModelField(targetType="String") String cover;
-  private final @ModelField(targetType="ID") String feedingPointCategoryId;
-  public String getId() {
-      return id;
-  }
-  
-  public String getName() {
-      return name;
-  }
-  
-  public String getDescription() {
-      return description;
-  }
-  
-  public String getCity() {
-      return city;
-  }
-  
-  public String getStreet() {
-      return street;
-  }
-  
-  public String getAddress() {
-      return address;
-  }
-  
-  public List<String> getImages() {
-      return images;
-  }
-  
-  public Point getPoint() {
-      return point;
-  }
-  
-  public Location getLocation() {
-      return location;
-  }
-  
-  public String getRegion() {
-      return region;
-  }
-  
-  public String getNeighborhood() {
-      return neighborhood;
-  }
-  
-  public Double getDistance() {
-      return distance;
-  }
-  
-  public FeedingPointStatus getStatus() {
-      return status;
-  }
-  
-  public List<FeedingPointI18n> getI18n() {
-      return i18n;
-  }
-  
-  public Temporal.DateTime getStatusUpdatedAt() {
-      return statusUpdatedAt;
-  }
-  
-  public Temporal.DateTime getCreatedAt() {
-      return createdAt;
-  }
-  
-  public Temporal.DateTime getUpdatedAt() {
-      return updatedAt;
-  }
-  
-  public String getCreatedBy() {
-      return createdBy;
-  }
-  
-  public String getUpdatedBy() {
-      return updatedBy;
-  }
-  
-  public String getOwner() {
-      return owner;
-  }
-  
-  public List<RelationPetFeedingPoint> getPets() {
-      return pets;
-  }
-  
-  public Category getCategory() {
-      return category;
-  }
-  
-  public List<RelationUserFeedingPoint> getUsers() {
-      return users;
-  }
-  
-  public List<Feeding> getFeedings() {
-      return feedings;
-  }
-  
-  public String getCover() {
-      return cover;
-  }
-  
-  public String getFeedingPointCategoryId() {
-      return feedingPointCategoryId;
-  }
-  
-  private FeedingPoint(String id, String name, String description, String city, String street, String address, List<String> images, Point point, Location location, String region, String neighborhood, Double distance, FeedingPointStatus status, List<FeedingPointI18n> i18n, Temporal.DateTime statusUpdatedAt, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String cover, String feedingPointCategoryId) {
-    this.id = id;
-    this.name = name;
-    this.description = description;
-    this.city = city;
-    this.street = street;
-    this.address = address;
-    this.images = images;
-    this.point = point;
-    this.location = location;
-    this.region = region;
-    this.neighborhood = neighborhood;
-    this.distance = distance;
-    this.status = status;
-    this.i18n = i18n;
-    this.statusUpdatedAt = statusUpdatedAt;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-    this.createdBy = createdBy;
-    this.updatedBy = updatedBy;
-    this.owner = owner;
-    this.cover = cover;
-    this.feedingPointCategoryId = feedingPointCategoryId;
-  }
-  
-  @Override
-   public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      } else if(obj == null || getClass() != obj.getClass()) {
-        return false;
-      } else {
-      FeedingPoint feedingPoint = (FeedingPoint) obj;
-      return ObjectsCompat.equals(getId(), feedingPoint.getId()) &&
-              ObjectsCompat.equals(getName(), feedingPoint.getName()) &&
-              ObjectsCompat.equals(getDescription(), feedingPoint.getDescription()) &&
-              ObjectsCompat.equals(getCity(), feedingPoint.getCity()) &&
-              ObjectsCompat.equals(getStreet(), feedingPoint.getStreet()) &&
-              ObjectsCompat.equals(getAddress(), feedingPoint.getAddress()) &&
-              ObjectsCompat.equals(getImages(), feedingPoint.getImages()) &&
-              ObjectsCompat.equals(getPoint(), feedingPoint.getPoint()) &&
-              ObjectsCompat.equals(getLocation(), feedingPoint.getLocation()) &&
-              ObjectsCompat.equals(getRegion(), feedingPoint.getRegion()) &&
-              ObjectsCompat.equals(getNeighborhood(), feedingPoint.getNeighborhood()) &&
-              ObjectsCompat.equals(getDistance(), feedingPoint.getDistance()) &&
-              ObjectsCompat.equals(getStatus(), feedingPoint.getStatus()) &&
-              ObjectsCompat.equals(getI18n(), feedingPoint.getI18n()) &&
-              ObjectsCompat.equals(getStatusUpdatedAt(), feedingPoint.getStatusUpdatedAt()) &&
-              ObjectsCompat.equals(getCreatedAt(), feedingPoint.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), feedingPoint.getUpdatedAt()) &&
-              ObjectsCompat.equals(getCreatedBy(), feedingPoint.getCreatedBy()) &&
-              ObjectsCompat.equals(getUpdatedBy(), feedingPoint.getUpdatedBy()) &&
-              ObjectsCompat.equals(getOwner(), feedingPoint.getOwner()) &&
-              ObjectsCompat.equals(getCover(), feedingPoint.getCover()) &&
-              ObjectsCompat.equals(getFeedingPointCategoryId(), feedingPoint.getFeedingPointCategoryId());
-      }
-  }
-  
-  @Override
-   public int hashCode() {
-    return new StringBuilder()
-      .append(getId())
-      .append(getName())
-      .append(getDescription())
-      .append(getCity())
-      .append(getStreet())
-      .append(getAddress())
-      .append(getImages())
-      .append(getPoint())
-      .append(getLocation())
-      .append(getRegion())
-      .append(getNeighborhood())
-      .append(getDistance())
-      .append(getStatus())
-      .append(getI18n())
-      .append(getStatusUpdatedAt())
-      .append(getCreatedAt())
-      .append(getUpdatedAt())
-      .append(getCreatedBy())
-      .append(getUpdatedBy())
-      .append(getOwner())
-      .append(getCover())
-      .append(getFeedingPointCategoryId())
-      .toString()
-      .hashCode();
-  }
-  
-  @Override
-   public String toString() {
-    return new StringBuilder()
-      .append("FeedingPoint {")
-      .append("id=" + String.valueOf(getId()) + ", ")
-      .append("name=" + String.valueOf(getName()) + ", ")
-      .append("description=" + String.valueOf(getDescription()) + ", ")
-      .append("city=" + String.valueOf(getCity()) + ", ")
-      .append("street=" + String.valueOf(getStreet()) + ", ")
-      .append("address=" + String.valueOf(getAddress()) + ", ")
-      .append("images=" + String.valueOf(getImages()) + ", ")
-      .append("point=" + String.valueOf(getPoint()) + ", ")
-      .append("location=" + String.valueOf(getLocation()) + ", ")
-      .append("region=" + String.valueOf(getRegion()) + ", ")
-      .append("neighborhood=" + String.valueOf(getNeighborhood()) + ", ")
-      .append("distance=" + String.valueOf(getDistance()) + ", ")
-      .append("status=" + String.valueOf(getStatus()) + ", ")
-      .append("i18n=" + String.valueOf(getI18n()) + ", ")
-      .append("statusUpdatedAt=" + String.valueOf(getStatusUpdatedAt()) + ", ")
-      .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
-      .append("updatedAt=" + String.valueOf(getUpdatedAt()) + ", ")
-      .append("createdBy=" + String.valueOf(getCreatedBy()) + ", ")
-      .append("updatedBy=" + String.valueOf(getUpdatedBy()) + ", ")
-      .append("owner=" + String.valueOf(getOwner()) + ", ")
-      .append("cover=" + String.valueOf(getCover()) + ", ")
-      .append("feedingPointCategoryId=" + String.valueOf(getFeedingPointCategoryId()))
-      .append("}")
-      .toString();
-  }
-  
-  public static NameStep builder() {
-      return new Builder();
-  }
-  
-  /**
-   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
-   * This is a convenience method to return an instance of the object with only its ID populated
-   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
-   * in a relationship.
-   * @param id the id of the existing item this instance will represent
-   * @return an instance of this model with only ID populated
-   */
-  public static FeedingPoint justId(String id) {
-    return new FeedingPoint(
-      id,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null
-    );
-  }
-  
-  public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id,
-      name,
-      description,
-      city,
-      street,
-      address,
-      images,
-      point,
-      location,
-      region,
-      neighborhood,
-      distance,
-      status,
-      i18n,
-      statusUpdatedAt,
-      createdAt,
-      updatedAt,
-      createdBy,
-      updatedBy,
-      owner,
-      cover,
-      feedingPointCategoryId);
-  }
-  public interface NameStep {
-    DescriptionStep name(String name);
-  }
-  
+    public static final QueryField ID = field("FeedingPoint", "id");
+    public static final QueryField NAME = field("FeedingPoint", "name");
+    public static final QueryField DESCRIPTION = field("FeedingPoint", "description");
+    public static final QueryField CITY = field("FeedingPoint", "city");
+    public static final QueryField STREET = field("FeedingPoint", "street");
+    public static final QueryField ADDRESS = field("FeedingPoint", "address");
+    public static final QueryField IMAGES = field("FeedingPoint", "images");
+    public static final QueryField POINT = field("FeedingPoint", "point");
+    public static final QueryField LOCATION = field("FeedingPoint", "location");
+    public static final QueryField REGION = field("FeedingPoint", "region");
+    public static final QueryField NEIGHBORHOOD = field("FeedingPoint", "neighborhood");
+    public static final QueryField DISTANCE = field("FeedingPoint", "distance");
+    public static final QueryField STATUS = field("FeedingPoint", "status");
+    public static final QueryField I18N = field("FeedingPoint", "i18n");
+    public static final QueryField STATUS_UPDATED_AT = field("FeedingPoint", "statusUpdatedAt");
+    public static final QueryField CREATED_AT = field("FeedingPoint", "createdAt");
+    public static final QueryField UPDATED_AT = field("FeedingPoint", "updatedAt");
+    public static final QueryField CREATED_BY = field("FeedingPoint", "createdBy");
+    public static final QueryField UPDATED_BY = field("FeedingPoint", "updatedBy");
+    public static final QueryField OWNER = field("FeedingPoint", "owner");
+    public static final QueryField COVER = field("FeedingPoint", "cover");
+    public static final QueryField FEEDING_POINT_CATEGORY_ID = field("FeedingPoint", "feedingPointCategoryId");
+    private final @ModelField(targetType="ID", isRequired = true) String id;
+    private final @ModelField(targetType="String", isRequired = true) String name;
+    private final @ModelField(targetType="String", isRequired = true) String description;
+    private final @ModelField(targetType="String", isRequired = true) String city;
+    private final @ModelField(targetType="String", isRequired = true) String street;
+    private final @ModelField(targetType="String", isRequired = true) String address;
+    private final @ModelField(targetType="String") List<String> images;
+    private final @ModelField(targetType="Point", isRequired = true) Point point;
+    private final @ModelField(targetType="Location", isRequired = true) Location location;
+    private final @ModelField(targetType="String", isRequired = true) String region;
+    private final @ModelField(targetType="String", isRequired = true) String neighborhood;
+    private final @ModelField(targetType="Float", isRequired = true) Double distance;
+    private final @ModelField(targetType="FeedingPointStatus", isRequired = true) FeedingPointStatus status;
+    private final @ModelField(targetType="FeedingPointI18n") List<FeedingPointI18n> i18n;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime statusUpdatedAt;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime createdAt;
+    private final @ModelField(targetType="AWSDateTime", isRequired = true) Temporal.DateTime updatedAt;
+    private final @ModelField(targetType="String") String createdBy;
+    private final @ModelField(targetType="String") String updatedBy;
+    private final @ModelField(targetType="String") String owner;
+    private final @ModelField(targetType="RelationPetFeedingPoint") @HasMany(associatedWith = "feedingPoint", type = RelationPetFeedingPoint.class) List<RelationPetFeedingPoint> pets = null;
+    private final @ModelField(targetType="Category") @HasOne(associatedWith = "id", type = Category.class) Category category = null;
+    private final @ModelField(targetType="RelationUserFeedingPoint") @HasMany(associatedWith = "feedingPoint", type = RelationUserFeedingPoint.class) List<RelationUserFeedingPoint> users = null;
+    private final @ModelField(targetType="String") String cover;
+    private final @ModelField(targetType="ID") String feedingPointCategoryId;
+    public String getId() {
+        return id;
+    }
 
-  public interface DescriptionStep {
-    CityStep description(String description);
-  }
-  
+    public String getName() {
+        return name;
+    }
 
-  public interface CityStep {
-    StreetStep city(String city);
-  }
-  
+    public String getDescription() {
+        return description;
+    }
 
-  public interface StreetStep {
-    AddressStep street(String street);
-  }
-  
+    public String getCity() {
+        return city;
+    }
 
-  public interface AddressStep {
-    PointStep address(String address);
-  }
-  
+    public String getStreet() {
+        return street;
+    }
 
-  public interface PointStep {
-    LocationStep point(Point point);
-  }
-  
+    public String getAddress() {
+        return address;
+    }
 
-  public interface LocationStep {
-    RegionStep location(Location location);
-  }
-  
+    public List<String> getImages() {
+        return images;
+    }
 
-  public interface RegionStep {
-    NeighborhoodStep region(String region);
-  }
-  
+    public Point getPoint() {
+        return point;
+    }
 
-  public interface NeighborhoodStep {
-    DistanceStep neighborhood(String neighborhood);
-  }
-  
+    public Location getLocation() {
+        return location;
+    }
 
-  public interface DistanceStep {
-    StatusStep distance(Double distance);
-  }
-  
+    public String getRegion() {
+        return region;
+    }
 
-  public interface StatusStep {
-    StatusUpdatedAtStep status(FeedingPointStatus status);
-  }
-  
+    public String getNeighborhood() {
+        return neighborhood;
+    }
 
-  public interface StatusUpdatedAtStep {
-    CreatedAtStep statusUpdatedAt(Temporal.DateTime statusUpdatedAt);
-  }
-  
+    public Double getDistance() {
+        return distance;
+    }
 
-  public interface CreatedAtStep {
-    UpdatedAtStep createdAt(Temporal.DateTime createdAt);
-  }
-  
+    public FeedingPointStatus getStatus() {
+        return status;
+    }
 
-  public interface UpdatedAtStep {
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
-  }
-  
+    public List<FeedingPointI18n> getI18n() {
+        return i18n;
+    }
 
-  public interface BuildStep {
-    FeedingPoint build();
-    BuildStep id(String id);
-    BuildStep images(List<String> images);
-    BuildStep i18n(List<FeedingPointI18n> i18n);
-    BuildStep createdBy(String createdBy);
-    BuildStep updatedBy(String updatedBy);
-    BuildStep owner(String owner);
-    BuildStep cover(String cover);
-    BuildStep feedingPointCategoryId(String feedingPointCategoryId);
-  }
-  
+    public Temporal.DateTime getStatusUpdatedAt() {
+        return statusUpdatedAt;
+    }
 
-  public static class Builder implements NameStep, DescriptionStep, CityStep, StreetStep, AddressStep, PointStep, LocationStep, RegionStep, NeighborhoodStep, DistanceStep, StatusStep, StatusUpdatedAtStep, CreatedAtStep, UpdatedAtStep, BuildStep {
-    private String id;
-    private String name;
-    private String description;
-    private String city;
-    private String street;
-    private String address;
-    private Point point;
-    private Location location;
-    private String region;
-    private String neighborhood;
-    private Double distance;
-    private FeedingPointStatus status;
-    private Temporal.DateTime statusUpdatedAt;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
-    private List<String> images;
-    private List<FeedingPointI18n> i18n;
-    private String createdBy;
-    private String updatedBy;
-    private String owner;
-    private String cover;
-    private String feedingPointCategoryId;
-    @Override
-     public FeedingPoint build() {
-        String id = this.id != null ? this.id : UUID.randomUUID().toString();
-        
-        return new FeedingPoint(
-          id,
-          name,
-          description,
-          city,
-          street,
-          address,
-          images,
-          point,
-          location,
-          region,
-          neighborhood,
-          distance,
-          status,
-          i18n,
-          statusUpdatedAt,
-          createdAt,
-          updatedAt,
-          createdBy,
-          updatedBy,
-          owner,
-          cover,
-          feedingPointCategoryId);
+    public Temporal.DateTime getCreatedAt() {
+        return createdAt;
     }
-    
-    @Override
-     public DescriptionStep name(String name) {
-        Objects.requireNonNull(name);
-        this.name = name;
-        return this;
+
+    public Temporal.DateTime getUpdatedAt() {
+        return updatedAt;
     }
-    
-    @Override
-     public CityStep description(String description) {
-        Objects.requireNonNull(description);
-        this.description = description;
-        return this;
+
+    public String getCreatedBy() {
+        return createdBy;
     }
-    
-    @Override
-     public StreetStep city(String city) {
-        Objects.requireNonNull(city);
-        this.city = city;
-        return this;
+
+    public String getUpdatedBy() {
+        return updatedBy;
     }
-    
-    @Override
-     public AddressStep street(String street) {
-        Objects.requireNonNull(street);
-        this.street = street;
-        return this;
+
+    public String getOwner() {
+        return owner;
     }
-    
-    @Override
-     public PointStep address(String address) {
-        Objects.requireNonNull(address);
-        this.address = address;
-        return this;
+
+    public List<RelationPetFeedingPoint> getPets() {
+        return pets;
     }
-    
-    @Override
-     public LocationStep point(Point point) {
-        Objects.requireNonNull(point);
-        this.point = point;
-        return this;
+
+    public Category getCategory() {
+        return category;
     }
-    
-    @Override
-     public RegionStep location(Location location) {
-        Objects.requireNonNull(location);
-        this.location = location;
-        return this;
+
+    public List<RelationUserFeedingPoint> getUsers() {
+        return users;
     }
-    
-    @Override
-     public NeighborhoodStep region(String region) {
-        Objects.requireNonNull(region);
-        this.region = region;
-        return this;
+
+    public String getCover() {
+        return cover;
     }
-    
-    @Override
-     public DistanceStep neighborhood(String neighborhood) {
-        Objects.requireNonNull(neighborhood);
-        this.neighborhood = neighborhood;
-        return this;
+
+    public String getFeedingPointCategoryId() {
+        return feedingPointCategoryId;
     }
-    
-    @Override
-     public StatusStep distance(Double distance) {
-        Objects.requireNonNull(distance);
-        this.distance = distance;
-        return this;
-    }
-    
-    @Override
-     public StatusUpdatedAtStep status(FeedingPointStatus status) {
-        Objects.requireNonNull(status);
-        this.status = status;
-        return this;
-    }
-    
-    @Override
-     public CreatedAtStep statusUpdatedAt(Temporal.DateTime statusUpdatedAt) {
-        Objects.requireNonNull(statusUpdatedAt);
-        this.statusUpdatedAt = statusUpdatedAt;
-        return this;
-    }
-    
-    @Override
-     public UpdatedAtStep createdAt(Temporal.DateTime createdAt) {
-        Objects.requireNonNull(createdAt);
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        Objects.requireNonNull(updatedAt);
-        this.updatedAt = updatedAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep images(List<String> images) {
-        this.images = images;
-        return this;
-    }
-    
-    @Override
-     public BuildStep i18n(List<FeedingPointI18n> i18n) {
-        this.i18n = i18n;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdBy(String createdBy) {
-        this.createdBy = createdBy;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedBy(String updatedBy) {
-        this.updatedBy = updatedBy;
-        return this;
-    }
-    
-    @Override
-     public BuildStep owner(String owner) {
-        this.owner = owner;
-        return this;
-    }
-    
-    @Override
-     public BuildStep cover(String cover) {
-        this.cover = cover;
-        return this;
-    }
-    
-    @Override
-     public BuildStep feedingPointCategoryId(String feedingPointCategoryId) {
-        this.feedingPointCategoryId = feedingPointCategoryId;
-        return this;
-    }
-    
-    /**
-     * @param id id
-     * @return Current Builder instance, for fluent method chaining
-     */
-    public BuildStep id(String id) {
+
+    private FeedingPoint(String id, String name, String description, String city, String street, String address, List<String> images, Point point, Location location, String region, String neighborhood, Double distance, FeedingPointStatus status, List<FeedingPointI18n> i18n, Temporal.DateTime statusUpdatedAt, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String cover, String feedingPointCategoryId) {
         this.id = id;
-        return this;
+        this.name = name;
+        this.description = description;
+        this.city = city;
+        this.street = street;
+        this.address = address;
+        this.images = images;
+        this.point = point;
+        this.location = location;
+        this.region = region;
+        this.neighborhood = neighborhood;
+        this.distance = distance;
+        this.status = status;
+        this.i18n = i18n;
+        this.statusUpdatedAt = statusUpdatedAt;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.createdBy = createdBy;
+        this.updatedBy = updatedBy;
+        this.owner = owner;
+        this.cover = cover;
+        this.feedingPointCategoryId = feedingPointCategoryId;
     }
-  }
-  
 
-  public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String description, String city, String street, String address, List<String> images, Point point, Location location, String region, String neighborhood, Double distance, FeedingPointStatus status, List<FeedingPointI18n> i18n, Temporal.DateTime statusUpdatedAt, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String cover, String feedingPointCategoryId) {
-      super.id(id);
-      super.name(name)
-        .description(description)
-        .city(city)
-        .street(street)
-        .address(address)
-        .point(point)
-        .location(location)
-        .region(region)
-        .neighborhood(neighborhood)
-        .distance(distance)
-        .status(status)
-        .statusUpdatedAt(statusUpdatedAt)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt)
-        .images(images)
-        .i18n(i18n)
-        .createdBy(createdBy)
-        .updatedBy(updatedBy)
-        .owner(owner)
-        .cover(cover)
-        .feedingPointCategoryId(feedingPointCategoryId);
-    }
-    
     @Override
-     public CopyOfBuilder name(String name) {
-      return (CopyOfBuilder) super.name(name);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if(obj == null || getClass() != obj.getClass()) {
+            return false;
+        } else {
+            FeedingPoint feedingPoint = (FeedingPoint) obj;
+            return ObjectsCompat.equals(getId(), feedingPoint.getId()) &&
+                    ObjectsCompat.equals(getName(), feedingPoint.getName()) &&
+                    ObjectsCompat.equals(getDescription(), feedingPoint.getDescription()) &&
+                    ObjectsCompat.equals(getCity(), feedingPoint.getCity()) &&
+                    ObjectsCompat.equals(getStreet(), feedingPoint.getStreet()) &&
+                    ObjectsCompat.equals(getAddress(), feedingPoint.getAddress()) &&
+                    ObjectsCompat.equals(getImages(), feedingPoint.getImages()) &&
+                    ObjectsCompat.equals(getPoint(), feedingPoint.getPoint()) &&
+                    ObjectsCompat.equals(getLocation(), feedingPoint.getLocation()) &&
+                    ObjectsCompat.equals(getRegion(), feedingPoint.getRegion()) &&
+                    ObjectsCompat.equals(getNeighborhood(), feedingPoint.getNeighborhood()) &&
+                    ObjectsCompat.equals(getDistance(), feedingPoint.getDistance()) &&
+                    ObjectsCompat.equals(getStatus(), feedingPoint.getStatus()) &&
+                    ObjectsCompat.equals(getI18n(), feedingPoint.getI18n()) &&
+                    ObjectsCompat.equals(getStatusUpdatedAt(), feedingPoint.getStatusUpdatedAt()) &&
+                    ObjectsCompat.equals(getCreatedAt(), feedingPoint.getCreatedAt()) &&
+                    ObjectsCompat.equals(getUpdatedAt(), feedingPoint.getUpdatedAt()) &&
+                    ObjectsCompat.equals(getCreatedBy(), feedingPoint.getCreatedBy()) &&
+                    ObjectsCompat.equals(getUpdatedBy(), feedingPoint.getUpdatedBy()) &&
+                    ObjectsCompat.equals(getOwner(), feedingPoint.getOwner()) &&
+                    ObjectsCompat.equals(getCover(), feedingPoint.getCover()) &&
+                    ObjectsCompat.equals(getFeedingPointCategoryId(), feedingPoint.getFeedingPointCategoryId());
+        }
     }
-    
+
     @Override
-     public CopyOfBuilder description(String description) {
-      return (CopyOfBuilder) super.description(description);
+    public int hashCode() {
+        return new StringBuilder()
+                .append(getId())
+                .append(getName())
+                .append(getDescription())
+                .append(getCity())
+                .append(getStreet())
+                .append(getAddress())
+                .append(getImages())
+                .append(getPoint())
+                .append(getLocation())
+                .append(getRegion())
+                .append(getNeighborhood())
+                .append(getDistance())
+                .append(getStatus())
+                .append(getI18n())
+                .append(getStatusUpdatedAt())
+                .append(getCreatedAt())
+                .append(getUpdatedAt())
+                .append(getCreatedBy())
+                .append(getUpdatedBy())
+                .append(getOwner())
+                .append(getCover())
+                .append(getFeedingPointCategoryId())
+                .toString()
+                .hashCode();
     }
-    
+
     @Override
-     public CopyOfBuilder city(String city) {
-      return (CopyOfBuilder) super.city(city);
+    public String toString() {
+        return new StringBuilder()
+                .append("FeedingPoint {")
+                .append("id=" + String.valueOf(getId()) + ", ")
+                .append("name=" + String.valueOf(getName()) + ", ")
+                .append("description=" + String.valueOf(getDescription()) + ", ")
+                .append("city=" + String.valueOf(getCity()) + ", ")
+                .append("street=" + String.valueOf(getStreet()) + ", ")
+                .append("address=" + String.valueOf(getAddress()) + ", ")
+                .append("images=" + String.valueOf(getImages()) + ", ")
+                .append("point=" + String.valueOf(getPoint()) + ", ")
+                .append("location=" + String.valueOf(getLocation()) + ", ")
+                .append("region=" + String.valueOf(getRegion()) + ", ")
+                .append("neighborhood=" + String.valueOf(getNeighborhood()) + ", ")
+                .append("distance=" + String.valueOf(getDistance()) + ", ")
+                .append("status=" + String.valueOf(getStatus()) + ", ")
+                .append("i18n=" + String.valueOf(getI18n()) + ", ")
+                .append("statusUpdatedAt=" + String.valueOf(getStatusUpdatedAt()) + ", ")
+                .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
+                .append("updatedAt=" + String.valueOf(getUpdatedAt()) + ", ")
+                .append("createdBy=" + String.valueOf(getCreatedBy()) + ", ")
+                .append("updatedBy=" + String.valueOf(getUpdatedBy()) + ", ")
+                .append("owner=" + String.valueOf(getOwner()) + ", ")
+                .append("cover=" + String.valueOf(getCover()) + ", ")
+                .append("feedingPointCategoryId=" + String.valueOf(getFeedingPointCategoryId()))
+                .append("}")
+                .toString();
     }
-    
-    @Override
-     public CopyOfBuilder street(String street) {
-      return (CopyOfBuilder) super.street(street);
+
+    public static NameStep builder() {
+        return new Builder();
     }
-    
-    @Override
-     public CopyOfBuilder address(String address) {
-      return (CopyOfBuilder) super.address(address);
+
+    /**
+     * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+     * This is a convenience method to return an instance of the object with only its ID populated
+     * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+     * in a relationship.
+     * @param id the id of the existing item this instance will represent
+     * @return an instance of this model with only ID populated
+     */
+    public static FeedingPoint justId(String id) {
+        return new FeedingPoint(
+                id,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
     }
-    
-    @Override
-     public CopyOfBuilder point(Point point) {
-      return (CopyOfBuilder) super.point(point);
+
+    public CopyOfBuilder copyOfBuilder() {
+        return new CopyOfBuilder(id,
+                name,
+                description,
+                city,
+                street,
+                address,
+                images,
+                point,
+                location,
+                region,
+                neighborhood,
+                distance,
+                status,
+                i18n,
+                statusUpdatedAt,
+                createdAt,
+                updatedAt,
+                createdBy,
+                updatedBy,
+                owner,
+                cover,
+                feedingPointCategoryId);
     }
-    
-    @Override
-     public CopyOfBuilder location(Location location) {
-      return (CopyOfBuilder) super.location(location);
+    public interface NameStep {
+        DescriptionStep name(String name);
     }
-    
-    @Override
-     public CopyOfBuilder region(String region) {
-      return (CopyOfBuilder) super.region(region);
+
+
+    public interface DescriptionStep {
+        CityStep description(String description);
     }
-    
-    @Override
-     public CopyOfBuilder neighborhood(String neighborhood) {
-      return (CopyOfBuilder) super.neighborhood(neighborhood);
+
+
+    public interface CityStep {
+        StreetStep city(String city);
     }
-    
-    @Override
-     public CopyOfBuilder distance(Double distance) {
-      return (CopyOfBuilder) super.distance(distance);
+
+
+    public interface StreetStep {
+        AddressStep street(String street);
     }
-    
-    @Override
-     public CopyOfBuilder status(FeedingPointStatus status) {
-      return (CopyOfBuilder) super.status(status);
+
+
+    public interface AddressStep {
+        PointStep address(String address);
     }
-    
-    @Override
-     public CopyOfBuilder statusUpdatedAt(Temporal.DateTime statusUpdatedAt) {
-      return (CopyOfBuilder) super.statusUpdatedAt(statusUpdatedAt);
+
+
+    public interface PointStep {
+        LocationStep point(Point point);
     }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
+
+
+    public interface LocationStep {
+        RegionStep location(Location location);
     }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
+
+
+    public interface RegionStep {
+        NeighborhoodStep region(String region);
     }
-    
-    @Override
-     public CopyOfBuilder images(List<String> images) {
-      return (CopyOfBuilder) super.images(images);
+
+
+    public interface NeighborhoodStep {
+        DistanceStep neighborhood(String neighborhood);
     }
-    
-    @Override
-     public CopyOfBuilder i18n(List<FeedingPointI18n> i18n) {
-      return (CopyOfBuilder) super.i18n(i18n);
+
+
+    public interface DistanceStep {
+        StatusStep distance(Double distance);
     }
-    
-    @Override
-     public CopyOfBuilder createdBy(String createdBy) {
-      return (CopyOfBuilder) super.createdBy(createdBy);
+
+
+    public interface StatusStep {
+        StatusUpdatedAtStep status(FeedingPointStatus status);
     }
-    
-    @Override
-     public CopyOfBuilder updatedBy(String updatedBy) {
-      return (CopyOfBuilder) super.updatedBy(updatedBy);
+
+
+    public interface StatusUpdatedAtStep {
+        CreatedAtStep statusUpdatedAt(Temporal.DateTime statusUpdatedAt);
     }
-    
-    @Override
-     public CopyOfBuilder owner(String owner) {
-      return (CopyOfBuilder) super.owner(owner);
+
+
+    public interface CreatedAtStep {
+        UpdatedAtStep createdAt(Temporal.DateTime createdAt);
     }
-    
-    @Override
-     public CopyOfBuilder cover(String cover) {
-      return (CopyOfBuilder) super.cover(cover);
+
+
+    public interface UpdatedAtStep {
+        BuildStep updatedAt(Temporal.DateTime updatedAt);
     }
-    
-    @Override
-     public CopyOfBuilder feedingPointCategoryId(String feedingPointCategoryId) {
-      return (CopyOfBuilder) super.feedingPointCategoryId(feedingPointCategoryId);
+
+
+    public interface BuildStep {
+        FeedingPoint build();
+        BuildStep id(String id);
+        BuildStep images(List<String> images);
+        BuildStep i18n(List<FeedingPointI18n> i18n);
+        BuildStep createdBy(String createdBy);
+        BuildStep updatedBy(String updatedBy);
+        BuildStep owner(String owner);
+        BuildStep cover(String cover);
+        BuildStep feedingPointCategoryId(String feedingPointCategoryId);
     }
-  }
-  
+
+
+    public static class Builder implements NameStep, DescriptionStep, CityStep, StreetStep, AddressStep, PointStep, LocationStep, RegionStep, NeighborhoodStep, DistanceStep, StatusStep, StatusUpdatedAtStep, CreatedAtStep, UpdatedAtStep, BuildStep {
+        private String id;
+        private String name;
+        private String description;
+        private String city;
+        private String street;
+        private String address;
+        private Point point;
+        private Location location;
+        private String region;
+        private String neighborhood;
+        private Double distance;
+        private FeedingPointStatus status;
+        private Temporal.DateTime statusUpdatedAt;
+        private Temporal.DateTime createdAt;
+        private Temporal.DateTime updatedAt;
+        private List<String> images;
+        private List<FeedingPointI18n> i18n;
+        private String createdBy;
+        private String updatedBy;
+        private String owner;
+        private String cover;
+        private String feedingPointCategoryId;
+        @Override
+        public FeedingPoint build() {
+            String id = this.id != null ? this.id : UUID.randomUUID().toString();
+
+            return new FeedingPoint(
+                    id,
+                    name,
+                    description,
+                    city,
+                    street,
+                    address,
+                    images,
+                    point,
+                    location,
+                    region,
+                    neighborhood,
+                    distance,
+                    status,
+                    i18n,
+                    statusUpdatedAt,
+                    createdAt,
+                    updatedAt,
+                    createdBy,
+                    updatedBy,
+                    owner,
+                    cover,
+                    feedingPointCategoryId);
+        }
+
+        @Override
+        public DescriptionStep name(String name) {
+            Objects.requireNonNull(name);
+            this.name = name;
+            return this;
+        }
+
+        @Override
+        public CityStep description(String description) {
+            Objects.requireNonNull(description);
+            this.description = description;
+            return this;
+        }
+
+        @Override
+        public StreetStep city(String city) {
+            Objects.requireNonNull(city);
+            this.city = city;
+            return this;
+        }
+
+        @Override
+        public AddressStep street(String street) {
+            Objects.requireNonNull(street);
+            this.street = street;
+            return this;
+        }
+
+        @Override
+        public PointStep address(String address) {
+            Objects.requireNonNull(address);
+            this.address = address;
+            return this;
+        }
+
+        @Override
+        public LocationStep point(Point point) {
+            Objects.requireNonNull(point);
+            this.point = point;
+            return this;
+        }
+
+        @Override
+        public RegionStep location(Location location) {
+            Objects.requireNonNull(location);
+            this.location = location;
+            return this;
+        }
+
+        @Override
+        public NeighborhoodStep region(String region) {
+            Objects.requireNonNull(region);
+            this.region = region;
+            return this;
+        }
+
+        @Override
+        public DistanceStep neighborhood(String neighborhood) {
+            Objects.requireNonNull(neighborhood);
+            this.neighborhood = neighborhood;
+            return this;
+        }
+
+        @Override
+        public StatusStep distance(Double distance) {
+            Objects.requireNonNull(distance);
+            this.distance = distance;
+            return this;
+        }
+
+        @Override
+        public StatusUpdatedAtStep status(FeedingPointStatus status) {
+            Objects.requireNonNull(status);
+            this.status = status;
+            return this;
+        }
+
+        @Override
+        public CreatedAtStep statusUpdatedAt(Temporal.DateTime statusUpdatedAt) {
+            Objects.requireNonNull(statusUpdatedAt);
+            this.statusUpdatedAt = statusUpdatedAt;
+            return this;
+        }
+
+        @Override
+        public UpdatedAtStep createdAt(Temporal.DateTime createdAt) {
+            Objects.requireNonNull(createdAt);
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        @Override
+        public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+            Objects.requireNonNull(updatedAt);
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        @Override
+        public BuildStep images(List<String> images) {
+            this.images = images;
+            return this;
+        }
+
+        @Override
+        public BuildStep i18n(List<FeedingPointI18n> i18n) {
+            this.i18n = i18n;
+            return this;
+        }
+
+        @Override
+        public BuildStep createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep updatedBy(String updatedBy) {
+            this.updatedBy = updatedBy;
+            return this;
+        }
+
+        @Override
+        public BuildStep owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        @Override
+        public BuildStep cover(String cover) {
+            this.cover = cover;
+            return this;
+        }
+
+        @Override
+        public BuildStep feedingPointCategoryId(String feedingPointCategoryId) {
+            this.feedingPointCategoryId = feedingPointCategoryId;
+            return this;
+        }
+
+        /**
+         * @param id id
+         * @return Current Builder instance, for fluent method chaining
+         */
+        public BuildStep id(String id) {
+            this.id = id;
+            return this;
+        }
+    }
+
+
+    public final class CopyOfBuilder extends Builder {
+        private CopyOfBuilder(String id, String name, String description, String city, String street, String address, List<String> images, Point point, Location location, String region, String neighborhood, Double distance, FeedingPointStatus status, List<FeedingPointI18n> i18n, Temporal.DateTime statusUpdatedAt, Temporal.DateTime createdAt, Temporal.DateTime updatedAt, String createdBy, String updatedBy, String owner, String cover, String feedingPointCategoryId) {
+            super.id(id);
+            super.name(name)
+                    .description(description)
+                    .city(city)
+                    .street(street)
+                    .address(address)
+                    .point(point)
+                    .location(location)
+                    .region(region)
+                    .neighborhood(neighborhood)
+                    .distance(distance)
+                    .status(status)
+                    .statusUpdatedAt(statusUpdatedAt)
+                    .createdAt(createdAt)
+                    .updatedAt(updatedAt)
+                    .images(images)
+                    .i18n(i18n)
+                    .createdBy(createdBy)
+                    .updatedBy(updatedBy)
+                    .owner(owner)
+                    .cover(cover)
+                    .feedingPointCategoryId(feedingPointCategoryId);
+        }
+
+        @Override
+        public CopyOfBuilder name(String name) {
+            return (CopyOfBuilder) super.name(name);
+        }
+
+        @Override
+        public CopyOfBuilder description(String description) {
+            return (CopyOfBuilder) super.description(description);
+        }
+
+        @Override
+        public CopyOfBuilder city(String city) {
+            return (CopyOfBuilder) super.city(city);
+        }
+
+        @Override
+        public CopyOfBuilder street(String street) {
+            return (CopyOfBuilder) super.street(street);
+        }
+
+        @Override
+        public CopyOfBuilder address(String address) {
+            return (CopyOfBuilder) super.address(address);
+        }
+
+        @Override
+        public CopyOfBuilder point(Point point) {
+            return (CopyOfBuilder) super.point(point);
+        }
+
+        @Override
+        public CopyOfBuilder location(Location location) {
+            return (CopyOfBuilder) super.location(location);
+        }
+
+        @Override
+        public CopyOfBuilder region(String region) {
+            return (CopyOfBuilder) super.region(region);
+        }
+
+        @Override
+        public CopyOfBuilder neighborhood(String neighborhood) {
+            return (CopyOfBuilder) super.neighborhood(neighborhood);
+        }
+
+        @Override
+        public CopyOfBuilder distance(Double distance) {
+            return (CopyOfBuilder) super.distance(distance);
+        }
+
+        @Override
+        public CopyOfBuilder status(FeedingPointStatus status) {
+            return (CopyOfBuilder) super.status(status);
+        }
+
+        @Override
+        public CopyOfBuilder statusUpdatedAt(Temporal.DateTime statusUpdatedAt) {
+            return (CopyOfBuilder) super.statusUpdatedAt(statusUpdatedAt);
+        }
+
+        @Override
+        public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+            return (CopyOfBuilder) super.createdAt(createdAt);
+        }
+
+        @Override
+        public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+            return (CopyOfBuilder) super.updatedAt(updatedAt);
+        }
+
+        @Override
+        public CopyOfBuilder images(List<String> images) {
+            return (CopyOfBuilder) super.images(images);
+        }
+
+        @Override
+        public CopyOfBuilder i18n(List<FeedingPointI18n> i18n) {
+            return (CopyOfBuilder) super.i18n(i18n);
+        }
+
+        @Override
+        public CopyOfBuilder createdBy(String createdBy) {
+            return (CopyOfBuilder) super.createdBy(createdBy);
+        }
+
+        @Override
+        public CopyOfBuilder updatedBy(String updatedBy) {
+            return (CopyOfBuilder) super.updatedBy(updatedBy);
+        }
+
+        @Override
+        public CopyOfBuilder owner(String owner) {
+            return (CopyOfBuilder) super.owner(owner);
+        }
+
+        @Override
+        public CopyOfBuilder cover(String cover) {
+            return (CopyOfBuilder) super.cover(cover);
+        }
+
+        @Override
+        public CopyOfBuilder feedingPointCategoryId(String feedingPointCategoryId) {
+            return (CopyOfBuilder) super.feedingPointCategoryId(feedingPointCategoryId);
+        }
+    }
+
 }

--- a/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingPointDetails.java
+++ b/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingPointDetails.java
@@ -1,0 +1,85 @@
+package com.amplifyframework.datastore.generated.model;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import java.util.Objects;
+
+/** This is an auto generated class representing the FeedingPointDetails type in your schema. */
+public final class FeedingPointDetails {
+  private final String address;
+  public String getAddress() {
+      return address;
+  }
+  
+  private FeedingPointDetails(String address) {
+    this.address = address;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      FeedingPointDetails feedingPointDetails = (FeedingPointDetails) obj;
+      return ObjectsCompat.equals(getAddress(), feedingPointDetails.getAddress());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getAddress())
+      .toString()
+      .hashCode();
+  }
+  
+  public static AddressStep builder() {
+      return new Builder();
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(address);
+  }
+  public interface AddressStep {
+    BuildStep address(String address);
+  }
+  
+
+  public interface BuildStep {
+    FeedingPointDetails build();
+  }
+  
+
+  public static class Builder implements AddressStep, BuildStep {
+    private String address;
+    @Override
+     public FeedingPointDetails build() {
+        
+        return new FeedingPointDetails(
+          address);
+    }
+    
+    @Override
+     public BuildStep address(String address) {
+        Objects.requireNonNull(address);
+        this.address = address;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String address) {
+      super.address(address);
+    }
+    
+    @Override
+     public CopyOfBuilder address(String address) {
+      return (CopyOfBuilder) super.address(address);
+    }
+  }
+  
+}

--- a/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingUsers.java
+++ b/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/FeedingUsers.java
@@ -1,0 +1,166 @@
+package com.amplifyframework.datastore.generated.model;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+import com.amplifyframework.core.model.temporal.Temporal;
+
+import java.util.List;
+import java.util.UUID;
+
+/** This is an auto generated class representing the FeedingUsers type in your schema. */
+@SuppressWarnings("all")
+@ModelConfig(pluralName = "FeedingUsers", authRules = {
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Administrator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Moderator" }, provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = "cognito:groups", groups = { "Volunteer" }, provider = "userPools", operations = { ModelOperation.READ }),
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = "owner", identityClaim = "cognito:username", provider = "userPools", operations = { ModelOperation.CREATE, ModelOperation.READ, ModelOperation.UPDATE, ModelOperation.DELETE }),
+  @AuthRule(allow = AuthStrategy.PUBLIC, provider = "apiKey", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+  @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.READ })
+})
+public final class FeedingUsers implements Model {
+  public static final QueryField ID = field("FeedingUsers", "id");
+  public static final QueryField ATTRIBUTES = field("FeedingUsers", "attributes");
+  private final @ModelField(targetType="ID", isRequired = true) String id;
+  private final @ModelField(targetType="UserAttribute") List<UserAttribute> attributes;
+  private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType="AWSDateTime", isReadOnly = true) Temporal.DateTime updatedAt;
+  public String getId() {
+      return id;
+  }
+  
+  public List<UserAttribute> getAttributes() {
+      return attributes;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private FeedingUsers(String id, List<UserAttribute> attributes) {
+    this.id = id;
+    this.attributes = attributes;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      FeedingUsers feedingUsers = (FeedingUsers) obj;
+      return ObjectsCompat.equals(getId(), feedingUsers.getId()) &&
+              ObjectsCompat.equals(getAttributes(), feedingUsers.getAttributes()) &&
+              ObjectsCompat.equals(getCreatedAt(), feedingUsers.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), feedingUsers.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getAttributes())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append("FeedingUsers {")
+      .append("id=" + String.valueOf(getId()) + ", ")
+      .append("attributes=" + String.valueOf(getAttributes()) + ", ")
+      .append("createdAt=" + String.valueOf(getCreatedAt()) + ", ")
+      .append("updatedAt=" + String.valueOf(getUpdatedAt()))
+      .append("}")
+      .toString();
+  }
+  
+  public static BuildStep builder() {
+      return new Builder();
+  }
+  
+  /**
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   */
+  public static FeedingUsers justId(String id) {
+    return new FeedingUsers(
+      id,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      attributes);
+  }
+  public interface BuildStep {
+    FeedingUsers build();
+    BuildStep id(String id);
+    BuildStep attributes(List<UserAttribute> attributes);
+  }
+  
+
+  public static class Builder implements BuildStep {
+    private String id;
+    private List<UserAttribute> attributes;
+    @Override
+     public FeedingUsers build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new FeedingUsers(
+          id,
+          attributes);
+    }
+    
+    @Override
+     public BuildStep attributes(List<UserAttribute> attributes) {
+        this.attributes = attributes;
+        return this;
+    }
+    
+    /**
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     */
+    public BuildStep id(String id) {
+        this.id = id;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, List<UserAttribute> attributes) {
+      super.id(id);
+      super.attributes(attributes);
+    }
+    
+    @Override
+     public CopyOfBuilder attributes(List<UserAttribute> attributes) {
+      return (CopyOfBuilder) super.attributes(attributes);
+    }
+  }
+  
+}

--- a/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/UserAttribute.java
+++ b/library/codegen/src/main/java/com/amplifyframework/datastore/generated/model/UserAttribute.java
@@ -1,0 +1,109 @@
+package com.amplifyframework.datastore.generated.model;
+
+
+import androidx.core.util.ObjectsCompat;
+
+import java.util.Objects;
+
+/** This is an auto generated class representing the UserAttribute type in your schema. */
+public final class UserAttribute {
+  private final String Name;
+  private final String Value;
+  public String getName() {
+      return Name;
+  }
+  
+  public String getValue() {
+      return Value;
+  }
+  
+  private UserAttribute(String Name, String Value) {
+    this.Name = Name;
+    this.Value = Value;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      UserAttribute userAttribute = (UserAttribute) obj;
+      return ObjectsCompat.equals(getName(), userAttribute.getName()) &&
+              ObjectsCompat.equals(getValue(), userAttribute.getValue());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getName())
+      .append(getValue())
+      .toString()
+      .hashCode();
+  }
+  
+  public static NameStep builder() {
+      return new Builder();
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(Name,
+      Value);
+  }
+  public interface NameStep {
+    BuildStep name(String name);
+  }
+  
+
+  public interface BuildStep {
+    UserAttribute build();
+    BuildStep value(String value);
+  }
+  
+
+  public static class Builder implements NameStep, BuildStep {
+    private String Name;
+    private String Value;
+    @Override
+     public UserAttribute build() {
+        
+        return new UserAttribute(
+          Name,
+          Value);
+    }
+    
+    @Override
+     public BuildStep name(String name) {
+        Objects.requireNonNull(name);
+        this.Name = name;
+        return this;
+    }
+    
+    @Override
+     public BuildStep value(String value) {
+        this.Value = value;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String name, String value) {
+      super.name(name)
+        .value(value);
+    }
+    
+    @Override
+     public CopyOfBuilder name(String name) {
+      return (CopyOfBuilder) super.name(name);
+    }
+    
+    @Override
+     public CopyOfBuilder value(String value) {
+      return (CopyOfBuilder) super.value(value);
+    }
+  }
+  
+}

--- a/shared/feature/feeding/src/debug/java/com/epmedu/animeal/feeding/di/FeedDataModule.kt
+++ b/shared/feature/feeding/src/debug/java/com/epmedu/animeal/feeding/di/FeedDataModule.kt
@@ -58,6 +58,7 @@ object FeedDataModule {
     fun providesFeedingRepository(
         authApi: AuthAPI,
         feedingAPI: FeedingApi,
+        feedingPointApi: FeedingPointApi,
         favouriteRepository: FavouriteRepository,
         usersRepository: UsersRepository,
         debugMenuRepository: DebugMenuRepository,
@@ -71,6 +72,7 @@ object FeedDataModule {
                     dispatchers = Dispatchers,
                     authApi = authApi,
                     feedingApi = feedingAPI,
+                    feedingPointApi = feedingPointApi,
                     favouriteRepository = favouriteRepository,
                     usersRepository = usersRepository
                 )

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/DataToDomainFeedingMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/DataToDomainFeedingMapper.kt
@@ -1,9 +1,11 @@
 package com.epmedu.animeal.feeding.data.mapper
 
+import com.amplifyframework.datastore.generated.model.FeedingPoint
 import com.amplifyframework.datastore.generated.model.Feeding as DataFeeding
 import com.epmedu.animeal.feeding.domain.model.UserFeeding as DomainFeeding
 
-fun DataFeeding.toDomain(isFavourite: Boolean) = DomainFeeding(
-    feedingPoint = feedingPoint.toDomainFeedingPoint(isFavourite),
-    createdAt = createdAt.toDate()
-)
+fun DataFeeding.toDomain(isFavourite: Boolean, feedingPoint: FeedingPoint) =
+    DomainFeeding(
+        feedingPoint = feedingPoint.toDomainFeedingPoint(isFavourite),
+        createdAt = createdAt.toDate()
+    )

--- a/shared/feature/feeding/src/release/java/com/epmedu/animeal/feeding/di/FeedDataModule.kt
+++ b/shared/feature/feeding/src/release/java/com/epmedu/animeal/feeding/di/FeedDataModule.kt
@@ -41,6 +41,7 @@ object FeedDataModule {
     fun providesFeedingRepository(
         authApi: AuthAPI,
         feedingAPI: FeedingApi,
+        feedingPointApi: FeedingPointApi,
         favouriteRepository: FavouriteRepository,
         usersRepository: UsersRepository
     ): FeedingRepository {
@@ -48,6 +49,7 @@ object FeedDataModule {
             dispatchers = Dispatchers,
             authApi = authApi,
             feedingApi = feedingAPI,
+            feedingPointApi = feedingPointApi,
             favouriteRepository = favouriteRepository,
             usersRepository = usersRepository
         )


### PR DESCRIPTION
Updates latest graphQL models.

Updates of graphQL files and and schema in json format is still missing.

**Changes**

- Since `Feeding` model doesn't contain `FeedingPoint` model anymore, I used the `feedingPointFeedingsId` to get it directly from `FeedingPointApi`
- `FeedingPointApi` dependencies added at `FeedDataModule` for debug and release builds.