### PR TITLE
fix/EPMEDU-2292 There is not appropriate message for parallel booking

### DIFF
--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/model/DomainFeedState.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/model/DomainFeedState.kt
@@ -5,6 +5,10 @@ data class DomainFeedState(
     val feedingConfirmationState: DomainFeedingConfirmationState = DomainFeedingConfirmationState.Dismissed,
 )
 
-enum class DomainFeedingConfirmationState {
-    Dismissed, Loading, Showing, FeedingStarted
+sealed interface DomainFeedingConfirmationState {
+    object Dismissed : DomainFeedingConfirmationState
+    object Loading : DomainFeedingConfirmationState
+    object Showing : DomainFeedingConfirmationState
+    object FeedingStarted : DomainFeedingConfirmationState
+    object FeedingWasAlreadyBooked : DomainFeedingConfirmationState
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/mapper/FeedStateMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/mapper/FeedStateMapper.kt
@@ -40,7 +40,8 @@ internal fun FeedingConfirmationState.toDomainFeedingConfirmationState(): Domain
         FeedingConfirmationState.Loading -> DomainFeedingConfirmationState.Loading
         FeedingConfirmationState.Showing -> DomainFeedingConfirmationState.Showing
         FeedingConfirmationState.FeedingStarted -> DomainFeedingConfirmationState.FeedingStarted
-        else -> DomainFeedingConfirmationState.Dismissed
+        FeedingConfirmationState.FeedingWasAlreadyBooked -> DomainFeedingConfirmationState.FeedingWasAlreadyBooked
+        FeedingConfirmationState.Dismissed -> DomainFeedingConfirmationState.Dismissed
     }
 
 internal fun DomainFeedingConfirmationState.toPresentationFeedingConfirmationState(): FeedingConfirmationState =
@@ -48,5 +49,6 @@ internal fun DomainFeedingConfirmationState.toPresentationFeedingConfirmationSta
         DomainFeedingConfirmationState.Loading -> FeedingConfirmationState.Loading
         DomainFeedingConfirmationState.Showing -> FeedingConfirmationState.Showing
         DomainFeedingConfirmationState.FeedingStarted -> FeedingConfirmationState.FeedingStarted
-        else -> FeedingConfirmationState.Dismissed
+        DomainFeedingConfirmationState.FeedingWasAlreadyBooked -> FeedingConfirmationState.FeedingWasAlreadyBooked
+        DomainFeedingConfirmationState.Dismissed -> FeedingConfirmationState.Dismissed
     }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/FeedingConfirmationState.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/FeedingConfirmationState.kt
@@ -1,5 +1,9 @@
 package com.epmedu.animeal.feeding.presentation.viewmodel
 
-enum class FeedingConfirmationState {
-    Dismissed, Loading, Showing, FeedingStarted, FeedingWasAlreadyBooked
+sealed interface FeedingConfirmationState {
+    object Dismissed : FeedingConfirmationState
+    object Loading : FeedingConfirmationState
+    object Showing : FeedingConfirmationState
+    object FeedingStarted : FeedingConfirmationState
+    object FeedingWasAlreadyBooked : FeedingConfirmationState
 }


### PR DESCRIPTION
Fixes logic when showing message of a feeding booked already.

When mapping domain to data objects (and viceversa) exhausts the whole options. Additionally adds missing `FeedingWasAlreadyBooked`.

Steps to reproduce (Need 2 devices/emulators with different accounts logged in):

https://github.com/AnimealProject/animeal_android/assets/4513325/bcd4617b-14c0-4d64-bb3e-01665dd471f2

