### PR TITLE
[EPMEDU-2490]: Add loading state to sign in flow screens

### DIFF
--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/EnterCodeScreen.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/EnterCodeScreen.kt
@@ -10,8 +10,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.epmedu.animeal.common.route.MainRoute
 import com.epmedu.animeal.common.route.SignUpRoute
 import com.epmedu.animeal.extensions.currentOrThrow
+import com.epmedu.animeal.foundation.effect.DisplayedEffect
 import com.epmedu.animeal.navigation.navigator.LocalNavigator
 import com.epmedu.animeal.navigation.navigator.Navigator
+import com.epmedu.animeal.signup.entercode.presentation.EnterCodeScreenEvent.ScreenDisplayed
 import com.epmedu.animeal.signup.entercode.presentation.viewmodel.EnterCodeEvent.NavigateToFinishProfile
 import com.epmedu.animeal.signup.entercode.presentation.viewmodel.EnterCodeEvent.NavigateToHomeScreen
 import com.epmedu.animeal.signup.entercode.presentation.viewmodel.EnterCodeViewModel
@@ -54,6 +56,10 @@ fun EnterCodeScreen() {
 
     LaunchedEffect(state.isError) {
         if (state.isError) focusRequester.requestFocus()
+    }
+
+    DisplayedEffect {
+        viewModel.handleEvents(ScreenDisplayed)
     }
 }
 

--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/EnterCodeScreenEvent.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/EnterCodeScreenEvent.kt
@@ -1,0 +1,5 @@
+package com.epmedu.animeal.signup.entercode.presentation
+
+internal sealed interface EnterCodeScreenEvent {
+    object ScreenDisplayed : EnterCodeScreenEvent
+}

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreen.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.epmedu.animeal.common.route.SignUpRoute
 import com.epmedu.animeal.extensions.currentOrThrow
+import com.epmedu.animeal.foundation.effect.DisplayedEffect
 import com.epmedu.animeal.navigation.navigator.LocalNavigator
+import com.epmedu.animeal.signup.enterphone.presentation.EnterPhoneScreenEvent.ScreenDisplayed
 import com.epmedu.animeal.signup.enterphone.presentation.viewmodel.EnterPhoneEvent
 import com.epmedu.animeal.signup.enterphone.presentation.viewmodel.EnterPhoneViewModel
 
@@ -37,5 +39,9 @@ fun EnterPhoneScreen() {
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
+    }
+
+    DisplayedEffect {
+        viewModel.handleEvents(ScreenDisplayed)
     }
 }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenEvent.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenEvent.kt
@@ -6,4 +6,5 @@ sealed interface EnterPhoneScreenEvent {
     data class UpdatePhoneNumber(val phoneNumber: String) : EnterPhoneScreenEvent
     data class RegionChosen(val region: Region) : EnterPhoneScreenEvent
     object NextButtonClicked : EnterPhoneScreenEvent
+    object ScreenDisplayed : EnterPhoneScreenEvent
 }

--- a/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/FinishProfileScreen.kt
+++ b/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/FinishProfileScreen.kt
@@ -10,9 +10,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.epmedu.animeal.common.route.MainRoute
 import com.epmedu.animeal.common.route.SignUpRoute
 import com.epmedu.animeal.extensions.currentOrThrow
+import com.epmedu.animeal.foundation.effect.DisplayedEffect
 import com.epmedu.animeal.navigation.navigator.LocalNavigator
 import com.epmedu.animeal.navigation.navigator.Navigator
 import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent.Cancel
+import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent.ScreenDisplayed
 import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent.Submit
 import com.epmedu.animeal.signup.finishprofile.presentation.viewmodel.FinishProfileEvent
 import com.epmedu.animeal.signup.finishprofile.presentation.viewmodel.FinishProfileViewModel
@@ -39,6 +41,10 @@ fun FinishProfileScreen() {
                 }
             }
         }
+    }
+
+    DisplayedEffect {
+        viewModel.handleScreenEvents(ScreenDisplayed)
     }
 
     FinishProfileScreenUI(

--- a/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/FinishProfileScreenEvent.kt
+++ b/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/FinishProfileScreenEvent.kt
@@ -3,4 +3,5 @@ package com.epmedu.animeal.signup.finishprofile.presentation
 internal sealed interface FinishProfileScreenEvent {
     object Cancel : FinishProfileScreenEvent
     object Submit : FinishProfileScreenEvent
+    object ScreenDisplayed : FinishProfileScreenEvent
 }

--- a/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/viewmodel/FinishProfileViewModel.kt
+++ b/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/viewmodel/FinishProfileViewModel.kt
@@ -5,6 +5,7 @@ import com.epmedu.animeal.auth.AuthenticationType
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.ActionDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.DefaultEventDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.EventDelegate
+import com.epmedu.animeal.common.presentation.viewmodel.handler.loading.LoadingHandler
 import com.epmedu.animeal.networkuser.domain.usecase.DeleteNetworkUserUseCase
 import com.epmedu.animeal.networkuser.domain.usecase.UpdateNetworkProfileUseCase
 import com.epmedu.animeal.networkuser.domain.usecase.authenticationtype.GetAuthenticationTypeUseCase
@@ -22,6 +23,7 @@ import com.epmedu.animeal.profile.presentation.viewmodel.BaseProfileViewModel
 import com.epmedu.animeal.profile.presentation.viewmodel.ProfileState.FormState.EDITABLE
 import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent
 import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent.Cancel
+import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent.ScreenDisplayed
 import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreenEvent.Submit
 import com.epmedu.animeal.signup.finishprofile.presentation.viewmodel.FinishProfileEvent.NavigateBackToOnboarding
 import com.epmedu.animeal.signup.finishprofile.presentation.viewmodel.FinishProfileEvent.NavigateToConfirmPhone
@@ -44,7 +46,8 @@ internal class FinishProfileViewModel @Inject constructor(
     private val validateEmailUseCase: ValidateEmailUseCase,
     private val validatePhoneNumberUseCase: ValidatePhoneNumberUseCase,
     private val validateBirthDateUseCase: ValidateBirthDateUseCase,
-    private val logOutUseCase: LogOutUseCase
+    private val logOutUseCase: LogOutUseCase,
+    private val loadingHandler: LoadingHandler
 ) : BaseProfileViewModel(
     validateNameUseCase,
     validateSurnameUseCase,
@@ -105,6 +108,9 @@ internal class FinishProfileViewModel @Inject constructor(
                     is AuthenticationType.Facebook -> removeUnfinishedNetworkUser()
                 }
             }
+            ScreenDisplayed -> {
+                loadingHandler.hideLoading()
+            }
         }
     }
 
@@ -116,6 +122,7 @@ internal class FinishProfileViewModel @Inject constructor(
                     profile = profile.copy(phoneNumber = profile.phoneNumber),
                 )
             }
+            loadingHandler.showLoading()
             saveProfile()
         }
     }
@@ -184,7 +191,7 @@ internal class FinishProfileViewModel @Inject constructor(
                             }
                         )
                     },
-                    onError = {}
+                    onError = loadingHandler::hideLoading
                 )
             }
         }

--- a/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/OnboardingScreen.kt
+++ b/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/OnboardingScreen.kt
@@ -16,6 +16,8 @@ import com.epmedu.animeal.navigation.navigator.LocalNavigator
 import com.epmedu.animeal.navigation.navigator.Navigator
 import com.epmedu.animeal.resources.R
 import com.epmedu.animeal.signup.onboarding.presentation.OnboardingScreenEvent.RedirectedFromFacebookWebUi
+import com.epmedu.animeal.signup.onboarding.presentation.OnboardingScreenEvent.SignInWithFacebookClicked
+import com.epmedu.animeal.signup.onboarding.presentation.OnboardingScreenEvent.SignInWithMobileClicked
 import com.epmedu.animeal.signup.onboarding.presentation.viewmodel.OnboardingState
 import com.epmedu.animeal.signup.onboarding.presentation.viewmodel.OnboardingViewModel
 
@@ -30,9 +32,10 @@ fun OnboardingScreen() {
 
     OnboardingScreenUI(
         onSignInMobile = {
-            viewModel.handleEvent(OnboardingScreenEvent.SignInWithMobileClicked)
+            viewModel.handleEvent(SignInWithMobileClicked)
         },
         onSignInFacebook = {
+            viewModel.handleEvent(SignInWithFacebookClicked)
             (activity as? FacebookSignInLauncher)?.signInWithFacebook(
                 onSuccess = { viewModel.handleEvent(RedirectedFromFacebookWebUi) },
                 onError = {

--- a/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/OnboardingScreenEvent.kt
+++ b/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/OnboardingScreenEvent.kt
@@ -4,4 +4,5 @@ sealed class OnboardingScreenEvent {
     object RedirectedFromFacebookWebUi : OnboardingScreenEvent()
     object SignInFinished : OnboardingScreenEvent()
     object SignInWithMobileClicked : OnboardingScreenEvent()
+    object SignInWithFacebookClicked : OnboardingScreenEvent()
 }

--- a/feature/signupflow/signup/build.gradle.kts
+++ b/feature/signupflow/signup/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(projects.feature.signupflow.onboarding)
 
     implementation(projects.library.common)
+    implementation(projects.library.foundation)
     implementation(projects.library.navigation)
 
     implementation(projects.shared.feature.router)

--- a/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/presentation/SignUpFlow.kt
+++ b/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/presentation/SignUpFlow.kt
@@ -1,12 +1,17 @@
 package com.epmedu.animeal.signup.presentation
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.epmedu.animeal.common.route.SignUpRoute
+import com.epmedu.animeal.foundation.loading.ShimmerLoading
 import com.epmedu.animeal.navigation.ScreenNavHost
 import com.epmedu.animeal.signup.entercode.presentation.EnterCodeScreen
 import com.epmedu.animeal.signup.enterphone.presentation.EnterPhoneScreen
@@ -14,10 +19,12 @@ import com.epmedu.animeal.signup.finishprofile.presentation.FinishProfileScreen
 import com.epmedu.animeal.signup.onboarding.presentation.OnboardingScreen
 import com.epmedu.animeal.signup.presentation.viewmodel.SignUpViewModel
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SignUpFlow() {
     val viewModel: SignUpViewModel = hiltViewModel()
     val state by viewModel.stateFlow.collectAsState()
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     ScreenNavHost(
         modifier = Modifier.statusBarsPadding(),
@@ -27,5 +34,10 @@ fun SignUpFlow() {
         screen(SignUpRoute.EnterPhone.name) { EnterPhoneScreen() }
         screen(SignUpRoute.EnterCode.name) { EnterCodeScreen() }
         screen(SignUpRoute.FinishProfile.name) { FinishProfileScreen() }
+    }
+
+    if (state.isLoading) {
+        keyboardController?.hide()
+        ShimmerLoading(modifier = Modifier.fillMaxSize(), shape = RectangleShape, alpha = 0.7f)
     }
 }

--- a/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/presentation/viewmodel/SignUpState.kt
+++ b/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/presentation/viewmodel/SignUpState.kt
@@ -3,5 +3,6 @@ package com.epmedu.animeal.signup.presentation.viewmodel
 import com.epmedu.animeal.common.route.SignUpRoute
 
 data class SignUpState(
-    val startDestination: SignUpRoute = SignUpRoute.Onboarding
+    val startDestination: SignUpRoute = SignUpRoute.Onboarding,
+    val isLoading: Boolean = false
 )

--- a/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/presentation/viewmodel/SignUpViewModel.kt
+++ b/feature/signupflow/signup/src/main/java/com/epmedu/animeal/signup/presentation/viewmodel/SignUpViewModel.kt
@@ -1,21 +1,38 @@
 package com.epmedu.animeal.signup.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.DefaultStateDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.StateDelegate
+import com.epmedu.animeal.common.presentation.viewmodel.handler.loading.LoadingHandler
 import com.epmedu.animeal.signup.domain.GetSignUpStartDestinationUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 internal class SignUpViewModel @Inject constructor(
-    private val getSignUpStartDestinationUseCase: GetSignUpStartDestinationUseCase
+    private val getSignUpStartDestinationUseCase: GetSignUpStartDestinationUseCase,
+    private val loadingHandler: LoadingHandler
 ) : ViewModel(),
     StateDelegate<SignUpState> by DefaultStateDelegate(SignUpState()) {
 
     init {
+        getStartDestination()
+        collectLoadingState()
+    }
+
+    private fun getStartDestination() {
         updateState {
             SignUpState(startDestination = getSignUpStartDestinationUseCase())
+        }
+    }
+
+    private fun collectLoadingState() {
+        viewModelScope.launch {
+            loadingHandler.isLoading.collect {
+                updateState { copy(isLoading = it) }
+            }
         }
     }
 }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreen.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreen.kt
@@ -13,13 +13,17 @@ import com.epmedu.animeal.camera.presentation.CameraView
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedViewModel
 import com.epmedu.animeal.foundation.bottomsheet.AnimealBottomSheetValue
 import com.epmedu.animeal.foundation.bottomsheet.rememberAnimealBottomSheetState
+import com.epmedu.animeal.foundation.effect.DisplayedEffect
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.CameraEvent
+import com.epmedu.animeal.home.presentation.HomeScreenEvent.ScreenCreated
+import com.epmedu.animeal.home.presentation.HomeScreenEvent.ScreenDisplayed
 import com.epmedu.animeal.home.presentation.model.CameraState
 import com.epmedu.animeal.home.presentation.viewmodel.HomeViewModel
 import com.epmedu.animeal.router.presentation.FeedingRouteState.Active
 import com.epmedu.animeal.router.presentation.FeedingRouteState.Disabled
 import kotlinx.coroutines.launch
 
+@Suppress("LongMethod")
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HomeScreen() {
@@ -79,7 +83,11 @@ fun HomeScreen() {
 
     LaunchedEffect(Unit) {
         lifecycleOwner.withCreated {
-            homeViewModel.handleEvents(HomeScreenEvent.ScreenDisplayed)
+            homeViewModel.handleEvents(ScreenCreated)
         }
+    }
+
+    DisplayedEffect {
+        homeViewModel.handleEvents(ScreenDisplayed)
     }
 }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenEvent.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenEvent.kt
@@ -26,6 +26,7 @@ sealed interface HomeScreenEvent {
     }
 
     object ErrorShowed : HomeScreenEvent
+    object ScreenCreated : HomeScreenEvent
     object ScreenDisplayed : HomeScreenEvent
     object InitialLocationWasDisplayed : HomeScreenEvent
 }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.epmedu.animeal.common.constants.Arguments.FORCED_FEEDING_POINT_ID
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.ActionDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.StateDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.handler.error.ErrorHandler
+import com.epmedu.animeal.common.presentation.viewmodel.handler.loading.LoadingHandler
 import com.epmedu.animeal.feeding.presentation.event.FeedingEvent
 import com.epmedu.animeal.feeding.presentation.event.FeedingPointEvent
 import com.epmedu.animeal.feeding.presentation.viewmodel.handler.feeding.FeedingHandler
@@ -18,6 +19,7 @@ import com.epmedu.animeal.home.domain.usecases.AnimalTypeUseCase
 import com.epmedu.animeal.home.presentation.HomeScreenEvent
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.CameraEvent
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.ErrorShowed
+import com.epmedu.animeal.home.presentation.HomeScreenEvent.ScreenCreated
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.ScreenDisplayed
 import com.epmedu.animeal.home.presentation.HomeScreenEvent.TimerCancellationEvent
 import com.epmedu.animeal.home.presentation.viewmodel.handlers.DefaultHomeHandler
@@ -48,6 +50,7 @@ internal class HomeViewModel @Inject constructor(
     private val locationProvider: LocationProvider,
     private val getTimerStateUseCase: GetTimerStateUseCase,
     private val animalTypeUseCase: AnimalTypeUseCase,
+    private val loadingHandler: LoadingHandler,
     stateDelegate: StateDelegate<HomeState>,
     defaultHomeHandler: DefaultHomeHandler,
     permissionsHandler: PermissionsHandler,
@@ -90,7 +93,8 @@ internal class HomeViewModel @Inject constructor(
             is RouteEvent -> handleRouteEvent(event = event)
             is TimerCancellationEvent -> viewModelScope.handleTimerCancellationEvent(event)
             is ErrorShowed -> hideError()
-            ScreenDisplayed -> onScreenDisplayed()
+            ScreenCreated -> onScreenCreated()
+            ScreenDisplayed -> loadingHandler.hideLoading()
             is CameraEvent -> viewModelScope.handleCameraEvent(event)
             HomeScreenEvent.InitialLocationWasDisplayed -> confirmInitialLocationWasDisplayed()
             is HomeScreenEvent.FeedingGalleryEvent -> viewModelScope.handleGalleryEvent(event)
@@ -98,7 +102,7 @@ internal class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun onScreenDisplayed() {
+    private fun onScreenCreated() {
         handleForcedFeedingPoint()
         viewModelScope.launch { fetchCurrentFeeding() }
     }

--- a/library/common/src/main/java/com/epmedu/animeal/common/di/AppModule.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/di/AppModule.kt
@@ -7,6 +7,8 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStoreFile
+import com.epmedu.animeal.common.presentation.viewmodel.handler.loading.LoadingHandler
+import com.epmedu.animeal.common.presentation.viewmodel.handler.loading.LoadingHandlerImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -32,4 +34,8 @@ internal object AppModule {
             produceFile = { context.preferencesDataStoreFile(DATA_STORE_PREFERENCES_KEY) }
         )
     }
+
+    @Singleton
+    @Provides
+    fun providesLoadingHandler(): LoadingHandler = LoadingHandlerImpl()
 }

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/handler/loading/LoadingHandler.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/handler/loading/LoadingHandler.kt
@@ -1,0 +1,11 @@
+package com.epmedu.animeal.common.presentation.viewmodel.handler.loading
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface LoadingHandler {
+    val isLoading: StateFlow<Boolean>
+
+    fun showLoading()
+
+    fun hideLoading()
+}

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/handler/loading/LoadingHandlerImpl.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/handler/loading/LoadingHandlerImpl.kt
@@ -1,0 +1,19 @@
+package com.epmedu.animeal.common.presentation.viewmodel.handler.loading
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class LoadingHandlerImpl : LoadingHandler {
+
+    private val _isLoading = MutableStateFlow(false)
+    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    override fun showLoading() {
+        _isLoading.value = true
+    }
+
+    override fun hideLoading() {
+        _isLoading.value = false
+    }
+}

--- a/library/foundation/build.gradle.kts
+++ b/library/foundation/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     implementation(libs.accompanist.systemuicontroller)
     implementation(libs.accompanist.pager.indicator)
 
+    implementation(libs.androidx.lifecycle)
+
     implementation(libs.compose.material)
     implementation(libs.compose.material.dialog.core)
     implementation(libs.compose.material.dialog.datetime)

--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/effect/DisplayedEffect.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/effect/DisplayedEffect.kt
@@ -1,0 +1,22 @@
+package com.epmedu.animeal.foundation.effect
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.withResumed
+
+/**
+ * Launches [onDisplay] lambda on first component composition
+ * when [Lifecycle.State] is at least [Lifecycle.State.RESUMED].
+ */
+@Composable
+fun DisplayedEffect(onDisplay: () -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(Unit) {
+        lifecycleOwner.withResumed {
+            onDisplay()
+        }
+    }
+}


### PR DESCRIPTION
[Jira ticket](https://jira.epam.com/jira/browse/EPMEDU-2490)

- Implemented loading state handling on `SignUpFlow` level to avoid screens blinking
- Added `DisplayedEffect` to hide loading when next screen is opened

| Flow | Sign in | Sign up |
| ------------- | ------------- | ------------- |
| Mobile | <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/c193b9f2-93a1-404f-a571-ea11f16be9c5"> | <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/1efb1669-6582-42a9-9f36-56919c4e2142"> |
| Facebook |  <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/ef7abef8-802b-4963-9eea-6a92b15da0c8"> | <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/26ee33c4-d851-4bfd-a667-cef5534a648d"> |
