### PR TITLE
[EPMEDU-2494]: After switch from app to app unable to deselect favorites points

### DIFF
--- a/library/api/src/main/java/com/epmedu/animeal/api/AnimealApiImpl.kt
+++ b/library/api/src/main/java/com/epmedu/animeal/api/AnimealApiImpl.kt
@@ -27,6 +27,8 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.retryWhen
+import java.net.SocketException
 import kotlin.coroutines.resume
 
 internal class AnimealApiImpl(
@@ -202,6 +204,8 @@ internal class AnimealApiImpl(
                 Log.i(LOG_TAG, "Flow with subscription $subscriptionId is closed")
                 graphQLOperation?.cancel()
             }
+        }.retryWhen { cause, attempt ->
+            cause.cause?.cause is SocketException && attempt <= SUBSCRIPTION_RETRY_ATTEMPTS
         }
     }
 
@@ -223,5 +227,6 @@ internal class AnimealApiImpl(
 
     private companion object {
         const val LOG_TAG = "AnimealApi"
+        const val SUBSCRIPTION_RETRY_ATTEMPTS = 3
     }
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FavouriteRepositoryImpl.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FavouriteRepositoryImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 
 internal class FavouriteRepositoryImpl(
     private val dispatchers: Dispatchers,
@@ -68,6 +69,7 @@ internal class FavouriteRepositoryImpl(
     }
 
     override suspend fun addFeedingPointToFavourites(feedingPointId: String): ActionResult<Unit> {
+        favouritesFlow.update { favouriteList -> favouriteList + Favourite.justId(feedingPointId) }
         return favouriteApi.addFavourite(
             feedingPointId = feedingPointId,
             userId = authApi.getCurrentUserId()
@@ -76,6 +78,9 @@ internal class FavouriteRepositoryImpl(
 
     override suspend fun removeFeedingPointFromFavourites(feedingPointId: String): ActionResult<Unit> {
         return favourites.find { it.feedingPointId == feedingPointId }?.let { favourite ->
+            favouritesFlow.update { favouriteList ->
+                favouriteList.filterNot { favourite -> favourite.feedingPointId == feedingPointId }
+            }
             favouriteApi.deleteFavourite(favourite.id)
         }.toActionResult()
     }


### PR DESCRIPTION
[Jira ticket](https://jira.epam.com/jira/browse/EPMEDU-2494)

The cause of this issue is a subscription failure that happens if app stays in the background for a while.

- Fixed by adding 3 retries on subscription failures
- Add updating favourites state in the repository to avoid relying only on subscriptions