### PR TITLE
[EPMEDU-2492]: Done button is not disabled when the incorrect verification code is entered

### DIFF
--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/ui/DigitField.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/ui/DigitField.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -47,7 +48,10 @@ internal fun DigitField(
             .size(width = 49.dp, height = 53.dp),
         textStyle = TextStyle(fontSize = 26.sp, textAlign = TextAlign.Center, lineHeight = 34.sp),
         isError = isError,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.NumberPassword,
+            imeAction = ImeAction.None
+        ),
         singleLine = true,
         colors = TextFieldDefaults.outlinedTextFieldColors(
             cursorColor = LocalContentColor.current,


### PR DESCRIPTION
[Jira ticket](https://jira.epam.com/jira/browse/EPMEDU-2492)

- Replaced `Done` `imeAction` with `None`
<img src="https://github.com/AnimealProject/animeal_android/assets/83027107/75b999a6-1e9e-4a29-835f-8152b7ad2072">
