### PR TITLE
[EPMEDU-2512]: Disable ssl proxying for prod releases

### DIFF
--- a/app/src/dev/res/xml/network_security_config.xml
+++ b/app/src/dev/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+
+    <base-config>
+
+        <trust-anchors>
+
+            <certificates src="user" />
+            <certificates src="system"/>
+
+        </trust-anchors>
+
+    </base-config>
+
+</network-security-config>

--- a/app/src/prod/res/xml/network_security_config.xml
+++ b/app/src/prod/res/xml/network_security_config.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
 
-<!--Temporary solution to allow testers use Charles TODO: Separate into flavors-->
-    <base-config>
+    <debug-overrides>
 
         <trust-anchors>
 
             <certificates src="user" />
-            <certificates src="system"/>
 
         </trust-anchors>
 
-    </base-config>
+    </debug-overrides>
 
 </network-security-config>

--- a/app/src/qa/res/xml/network_security_config.xml
+++ b/app/src/qa/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+
+    <base-config>
+
+        <trust-anchors>
+
+            <certificates src="user" />
+            <certificates src="system"/>
+
+        </trust-anchors>
+
+    </base-config>
+
+</network-security-config>


### PR DESCRIPTION
[Jira ticket](https://jira.epam.com/jira/browse/EPMEDU-2512)

  - Moved and duplicated `network_security_config.xml` to flavors resources
  - Replaced `network_security_config.xml` for prod with debug version

| Dev  | Prod Release |
| ------------- | ------------- |
| <img width="1074" alt="image" src="https://github.com/AnimealProject/animeal_android/assets/83027107/c9aed347-3e03-4ab7-9824-69d5867f8241">  | Not able to login while proxying <img width="1080" alt="image" src="https://github.com/AnimealProject/animeal_android/assets/83027107/be5b9e39-e845-4ce0-82e3-5c25f592e498"> |