### PR TITLE
[EPMEDU-2486] Nearest feeding point is opened after enabling GPS

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -152,8 +152,13 @@ internal class HomeViewModel @Inject constructor(
                         feedingRouteState = feedingRouteUpdate,
                     )
                 }
-                if (homeStateFlow.locationState !is LocationState.UndefinedLocation) {
-                    nearestFeedingJob.start()
+
+                if (feedingPointUpdate.feedingPoints.isNotEmpty()) {
+                    if (homeStateFlow.locationState !is LocationState.UndefinedLocation) {
+                        nearestFeedingJob.start()
+                    } else {
+                        nearestFeedingJob.cancel()
+                    }
                 }
             }.collect()
         }


### PR DESCRIPTION
Small fix for the nearest feeding point being opened only during the initial launch of the app with already granted permissions.