### PR TITLE
[EPMEDU-2617]: Resend code doesn't work while registering through Facebook

### DIFF
--- a/library/auth/src/main/java/com/epmedu/animeal/auth/di/AuthModule.kt
+++ b/library/auth/src/main/java/com/epmedu/animeal/auth/di/AuthModule.kt
@@ -18,8 +18,9 @@ object AuthModule {
     @Singleton
     @Provides
     fun providesAuthApi(
+        userAttributesAPI: UserAttributesAPI,
         tokenExpirationHandler: TokenExpirationHandler
-    ): AuthAPI = AuthAPIImpl(tokenExpirationHandler)
+    ): AuthAPI = AuthAPIImpl(userAttributesAPI, tokenExpirationHandler)
 
     @Singleton
     @Provides


### PR DESCRIPTION
- Replaced using `resendUserAttributeConfirmationCode` with just updating attribute, since it triggers code sending