### PR TITLE
[EPMEDU-2856]: Focus requester crashes the app

### DIFF
--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/EnterCodeScreen.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/EnterCodeScreen.kt
@@ -26,13 +26,22 @@ fun EnterCodeScreen() {
     val focusRequester = remember { FocusRequester() }
     val state by viewModel.stateFlow.collectAsState()
 
+    // remember lambdas to avoid excess code row and back button recompositions
+    // while resend code delay is ticking, not needed for resend button though
+    val onBack: () -> Unit = remember {
+        { navigator.popBackStack() }
+    }
+    val onDigitChange: (position: Int, digit: Int?) -> Unit = remember {
+        { position, digit ->
+            viewModel.changeDigit(position, digit)
+        }
+    }
+
     EnterCodeScreenUi(
         state = state,
         focusRequester = focusRequester,
-        onBack = navigator::popBackStack,
-        onDigitChange = { position, digit ->
-            viewModel.changeDigit(position, digit)
-        },
+        onBack = onBack,
+        onDigitChange = onDigitChange,
         onResend = {
             viewModel.resendCode()
             focusRequester.requestFocus()
@@ -40,8 +49,6 @@ fun EnterCodeScreen() {
     )
 
     LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-
         viewModel.events.collect {
             when (it) {
                 NavigateToFinishProfile -> {

--- a/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/ui/CodeRow.kt
+++ b/feature/signupflow/entercode/src/main/java/com/epmedu/animeal/signup/entercode/presentation/ui/CodeRow.kt
@@ -10,15 +10,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
+import com.epmedu.animeal.foundation.modifier.focusOnGloballyPositioned
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun CodeRow(
-    code: List<Int?>,
+    code: ImmutableList<Int?>,
     focusRequester: FocusRequester,
     onDigitChange: (position: Int, digit: Int?) -> Unit,
     modifier: Modifier = Modifier,
@@ -41,7 +43,11 @@ internal fun CodeRow(
                     onDigitChange(index, null)
                     if (index > 0) focusManager.moveFocus(FocusDirection.Previous)
                 },
-                modifier = if (index == 0) Modifier.focusRequester(focusRequester) else Modifier,
+                modifier = if (index == 0) {
+                    Modifier.focusOnGloballyPositioned(focusRequester)
+                } else {
+                    Modifier
+                },
                 isError = isError
             )
         }
@@ -54,14 +60,14 @@ private fun CodeRowPreview() {
     AnimealTheme {
         Column {
             CodeRow(
-                code = listOf(1, 2, null, null, null, null),
+                code = persistentListOf(1, 2, null, null, null, null),
                 focusRequester = FocusRequester(),
                 onDigitChange = { _, _ -> },
                 modifier = Modifier.padding(8.dp)
             )
             Divider()
             CodeRow(
-                code = listOf(1, 2, 3, 9, 5, 7),
+                code = persistentListOf(1, 2, 3, 9, 5, 7),
                 focusRequester = FocusRequester(),
                 onDigitChange = { _, _ -> },
                 modifier = Modifier.padding(8.dp),

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreen.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreen.kt
@@ -37,10 +37,6 @@ fun EnterPhoneScreen() {
         }
     }
 
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-
     DisplayedEffect {
         viewModel.handleEvents(ScreenDisplayed)
     }

--- a/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenUi.kt
+++ b/feature/signupflow/enterphone/src/main/java/com/epmedu/animeal/signup/enterphone/presentation/EnterPhoneScreenUi.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -27,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.epmedu.animeal.foundation.button.AnimealShortButton
 import com.epmedu.animeal.foundation.input.Flag
 import com.epmedu.animeal.foundation.input.PhoneNumberInput
+import com.epmedu.animeal.foundation.modifier.focusOnGloballyPositioned
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.foundation.topbar.BackButton
@@ -133,7 +133,7 @@ private fun ScaffoldAndBody(
                 prefix = state.prefix,
                 modifier = Modifier
                     .padding(top = 56.dp)
-                    .focusRequester(focusRequester),
+                    .focusOnGloballyPositioned(focusRequester),
                 format = state.format,
                 numberLength = state.numberLength,
                 useNumberFormatter = state.region == Region.GE,

--- a/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/FinishProfileScreen.kt
+++ b/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/FinishProfileScreen.kt
@@ -27,7 +27,6 @@ fun FinishProfileScreen() {
     val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
         viewModel.events.collect {
             when (it) {
                 FinishProfileEvent.NavigateBackToOnboarding -> {

--- a/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/ui/FinishProfileContent.kt
+++ b/feature/signupflow/finishprofile/src/main/java/com/epmedu/animeal/signup/finishprofile/presentation/ui/FinishProfileContent.kt
@@ -22,11 +22,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.epmedu.animeal.foundation.modifier.focusOnGloballyPositioned
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.foundation.topbar.BackButton
@@ -76,7 +76,7 @@ internal fun FinishProfileContent(
                 onEvent = onInputFormEvent,
                 modifier = Modifier
                     .padding(top = 24.dp)
-                    .focusRequester(focusRequester),
+                    .focusOnGloballyPositioned(focusRequester),
                 onCountryClick = {
                     keyboardController?.hide()
                     scope.launch { bottomSheetState.show() }

--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/modifier/FocusOnGloballyPositioned.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/modifier/FocusOnGloballyPositioned.kt
@@ -1,0 +1,32 @@
+package com.epmedu.animeal.foundation.modifier
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.onGloballyPositioned
+
+fun Modifier.focusOnGloballyPositioned(
+    focusRequester: FocusRequester,
+    focusOnce: Boolean = true,
+): Modifier = composed {
+    var isInitiallyFocused by remember { mutableStateOf(false) }
+
+    this
+        .focusRequester(focusRequester)
+        .onGloballyPositioned {
+            when {
+                focusOnce && isInitiallyFocused.not() -> {
+                    focusRequester.requestFocus()
+                    isInitiallyFocused = true
+                }
+                focusOnce.not() -> {
+                    focusRequester.requestFocus()
+                }
+            }
+        }
+}


### PR DESCRIPTION
[Jira ticket](https://jira.epam.com/jira/browse/EPMEDU-2856)

According to suggestions from the crashes, we must not request focus during composition, so I moved the calls into `onGloballyPositioned` callback to make them after composition
<img width="1090" alt="image" src="https://github.com/AnimealProject/animeal_android/assets/83027107/775d70c5-2fae-47ec-b531-abac2d812526">

Related crashes in Crashlytics: [first](https://console.firebase.google.com/u/0/project/animeal-project/crashlytics/app/android:com.epmedu.animeal/issues/6e24730271154cfc1c9caa121004ff7c?time=last-seven-days&types=crash), [second](https://console.firebase.google.com/u/0/project/animeal-project/crashlytics/app/android:com.epmedu.animeal/issues/77c90f3ad396a8c98de876d72d007700?time=last-seven-days&types=crash), [third](https://console.firebase.google.com/u/0/project/animeal-project/crashlytics/app/android:com.epmedu.animeal/issues/d62d6d66378966bea789b7481629b589?time=last-seven-days&types=crash)

  - Moved initial focus requesting to `onGloballyPositioned` callback
  - Optimised `EnterCodeScreen` recompositions count
  - Created `focusOnGloballyPositioned` extension