### PR TITLE
Refactor GetFeedingPointByIdUseCase to return null instead of exception in fallback case

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -207,7 +207,7 @@ internal class HomeViewModel @Inject constructor(
             val forcedFeedingPointId: String? = savedStateHandle[FORCED_FEEDING_POINT_ID]
             if (forcedFeedingPointId != null) {
                 savedStateHandle[FORCED_FEEDING_POINT_ID] = null
-                showFeedingPoint(forcedFeedingPointId).coordinates.let {
+                showFeedingPoint(forcedFeedingPointId)?.coordinates?.let {
                     collectLocations(Location(it.latitude(), it.longitude()))
                 }
             }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FeedingPointRepositoryImpl.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/repository/FeedingPointRepositoryImpl.kt
@@ -50,9 +50,8 @@ internal class FeedingPointRepositoryImpl(
         }
     }
 
-    override fun getFeedingPointById(id: String): FeedingPoint {
+    override fun getFeedingPointById(id: String): FeedingPoint? {
         return feedingPoints.find { it.id == id }
-            ?: throw IllegalArgumentException("No feeding point with id: $id")
     }
 
     private fun fetchFeedingPoints(): Flow<List<DomainFeedingPoint>> {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/repository/FeedingPointRepository.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/repository/FeedingPointRepository.kt
@@ -12,5 +12,5 @@ interface FeedingPointRepository {
         predicate: (FeedingPoint) -> Boolean
     ): Flow<List<FeedingPoint>>
 
-    fun getFeedingPointById(id: String): FeedingPoint
+    fun getFeedingPointById(id: String): FeedingPoint?
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/GetFeedingPointByIdUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/GetFeedingPointByIdUseCase.kt
@@ -1,8 +1,9 @@
 package com.epmedu.animeal.feeding.domain.usecase
 
+import com.epmedu.animeal.feeding.domain.model.FeedingPoint
 import com.epmedu.animeal.feeding.domain.repository.FeedingPointRepository
 
 class GetFeedingPointByIdUseCase(private val repository: FeedingPointRepository) {
 
-    operator fun invoke(id: String) = repository.getFeedingPointById(id)
+    operator fun invoke(id: String): FeedingPoint? = repository.getFeedingPointById(id)
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
@@ -112,27 +112,28 @@ class DefaultFeedingHandler(
     }
 
     private suspend fun startFeeding(id: String) {
-        val feedingPoint = getFeedingPointByIdUseCase(id)
-        updateState {
-            copy(
-                feedPoint = FeedingPointModel(feedingPoint)
+        getFeedingPointByIdUseCase(id)?.let { feedingPoint ->
+            updateState {
+                copy(
+                    feedPoint = FeedingPointModel(feedingPoint)
+                )
+            }
+            performFeedingAction(
+                action = startFeedingUseCase::invoke,
+                onSuccess = { currentFeedingPoint ->
+                    showSingleReservedFeedingPoint(currentFeedingPoint)
+                    startRoute()
+                    startTimer()
+                    updateFeedingState(
+                        feedPoint = FeedingPointModel(feedingPoint),
+                        feedingConfirmationState = FeedingStarted
+                    )
+                },
+                onError = {
+                    updateFeedingState(FeedingWasAlreadyBooked)
+                }
             )
         }
-        performFeedingAction(
-            action = startFeedingUseCase::invoke,
-            onSuccess = { currentFeedingPoint ->
-                showSingleReservedFeedingPoint(currentFeedingPoint)
-                startRoute()
-                startTimer()
-                updateFeedingState(
-                    feedPoint = FeedingPointModel(feedingPoint),
-                    feedingConfirmationState = FeedingStarted
-                )
-            },
-            onError = {
-                updateFeedingState(FeedingWasAlreadyBooked)
-            }
-        )
     }
 
     override fun CoroutineScope.cancelFeeding() {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/DefaultFeedingPointHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/DefaultFeedingPointHandler.kt
@@ -141,10 +141,12 @@ class DefaultFeedingPointHandler @Inject constructor(
         }
     }
 
-    override fun CoroutineScope.showFeedingPoint(feedingPointId: String): FeedingPointModel {
-        val forcedPoint = FeedingPointModel(getFeedingPointByIdUseCase(feedingPointId))
-        selectFeedingPoint(forcedPoint)
-        return forcedPoint
+    override fun CoroutineScope.showFeedingPoint(feedingPointId: String): FeedingPointModel? {
+        return getFeedingPointByIdUseCase(feedingPointId)?.let { feedingPoint ->
+            FeedingPointModel(feedingPoint).also {
+                selectFeedingPoint(it)
+            }
+        }
     }
 
     override fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel) {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/FeedingPointHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/FeedingPointHandler.kt
@@ -22,7 +22,7 @@ interface FeedingPointHandler {
 
     fun deselectFeedingPoint()
 
-    fun CoroutineScope.showFeedingPoint(feedingPointId: String): FeedingPointModel
+    fun CoroutineScope.showFeedingPoint(feedingPointId: String): FeedingPointModel?
 
     fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel)
 


### PR DESCRIPTION
This change is needed to prevent crashes when a feeding point associated to a feeding is removed, so we can just filter such feedings.