### PR TITLE
[EPMEDU-3291]: Location related features don't work if is opened from Feeding point

### DIFF
--- a/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/IntentGpsSettingsProvider.kt
+++ b/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/IntentGpsSettingsProvider.kt
@@ -31,6 +31,7 @@ internal class IntentGpsSettingsProvider(
             }
         )
 
+        trySend(gpsSettingState)
         gnssStatusCompat.registerCallback()
 
         awaitClose { gnssStatusCompat.unregisterCallback() }


### PR DESCRIPTION
[Jira issue](https://jira.epam.com/jira/browse/EPMEDU-3291)

### Description
 - Fixed by emitting current gps setting state after re-subscribing to the flow

### Video
https://github.com/AnimealProject/animeal_android/assets/83027107/ee6caf58-1e02-4a8b-aeab-e11926a611df