### PR TITLE
[EPMEDU-3292]: No feeding point in progress after app restart with opposite animal type

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -165,7 +165,10 @@ internal class HomeViewModel @Inject constructor(
                 }
 
                 if (feedingPointUpdate.feedingPoints.isNotEmpty()) {
-                    if (homeStateFlow.locationState !is LocationState.UndefinedLocation && nearestFeedingJob.isCompleted.not()) {
+                    if (homeStateFlow.locationState !is LocationState.UndefinedLocation &&
+                        nearestFeedingJob.isCompleted.not() &&
+                        feedingUpdate.feedPoint == null
+                    ) {
                         nearestFeedingJob.start()
                     } else {
                         nearestFeedingJob.cancel()

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/DefaultFeedingPointHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/DefaultFeedingPointHandler.kt
@@ -149,14 +149,16 @@ class DefaultFeedingPointHandler @Inject constructor(
         }
     }
 
-    override fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel) {
+    override suspend fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel) {
         val reservedFeedingPoint = feedingPoint.copy(feedStatus = FeedStatus.YELLOW)
         updateState {
             copy(
+                defaultAnimalType = reservedFeedingPoint.animalType,
                 currentFeedingPoint = null,
                 feedingPoints = persistentListOf(reservedFeedingPoint)
             )
         }
+        updateAnimalTypeSettingsUseCase(reservedFeedingPoint.animalType)
     }
 
     override fun CoroutineScope.handleFeedingPointEvent(event: FeedingPointEvent) {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/FeedingPointHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/FeedingPointHandler.kt
@@ -24,7 +24,7 @@ interface FeedingPointHandler {
 
     fun CoroutineScope.showFeedingPoint(feedingPointId: String): FeedingPointModel?
 
-    fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel)
+    suspend fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel)
 
     fun CoroutineScope.handleFeedingPointEvent(event: FeedingPointEvent)
 }


### PR DESCRIPTION
[Jira issue](https://jira.epam.com/jira/browse/EPMEDU-3292)

### Description
  - Fixed by updating animal type on showing the reserved feeding point
  - Fixed interference of nearest feeding point job with feeding in progress

### Video
https://github.com/AnimealProject/animeal_android/assets/83027107/a1aac8ce-fa92-4d00-8848-c1be2bd94b13