### PR TITLE
[EPMEDU-3293]: Feeding point image is empty when feeding is in progress

### DIFF
--- a/feature/tabsflow/home/build.gradle.kts
+++ b/feature/tabsflow/home/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(projects.shared.feature.camera)
     implementation(projects.shared.feature.feeding)
     implementation(projects.shared.feature.feedings)
+    implementation(projects.shared.feature.networkstorage)
     implementation(projects.shared.feature.networkuser)
     implementation(projects.shared.feature.permissions)
     implementation(projects.shared.feature.profile)

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/FeedingSheet.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/FeedingSheet.kt
@@ -27,7 +27,8 @@ fun FeedingSheet(
                 modifier = Modifier.wrapContentHeight(),
                 photos = feedingPhotos,
                 isUploadingNextImage = cameraState == CameraState.LoadingImageToServer,
-                feedingPointTitle = feedingPoint.title,
+                title = feedingPoint.title,
+                image = feedingPoint.image,
                 onDeletePhotoClick = onDeletePhotoClick,
                 onTakePhotoClick = onTakePhotoClick
             )

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/FeedingPointImage.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/FeedingPointImage.kt
@@ -1,4 +1,4 @@
-package com.epmedu.animeal.feedings.presentation.ui
+package com.epmedu.animeal.feeding.presentation.ui
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -7,13 +7,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.epmedu.animeal.networkstorage.domain.NetworkFile
 
 @Composable
-internal fun FeedingItemImage(image: NetworkFile?) {
+fun FeedingPointImage(
+    image: NetworkFile?,
+    contentDescription: String,
+    size: Dp = 80.dp
+) {
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
             .data(image?.url)
@@ -21,9 +26,9 @@ internal fun FeedingItemImage(image: NetworkFile?) {
             .crossfade(true)
             .build(),
         contentScale = ContentScale.Crop,
-        contentDescription = null,
+        contentDescription = contentDescription,
         modifier = Modifier
-            .size(80.dp)
+            .size(size)
             .clip(RoundedCornerShape(16.dp))
     )
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/FeedingPointItem.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/FeedingPointItem.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.ExperimentalMaterialApi
@@ -19,15 +18,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.epmedu.animeal.common.constants.DefaultConstants.EMPTY_STRING
 import com.epmedu.animeal.feeding.presentation.model.FeedStatus
 import com.epmedu.animeal.foundation.button.AnimealHeartButton
@@ -64,22 +58,10 @@ fun FeedingPointItem(
                 .padding(12.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Card(
-                modifier = Modifier
-                    .size(80.dp)
-                    .clip(RoundedCornerShape(16.dp)),
-                elevation = 8.dp
-            ) {
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(image?.url)
-                        .crossfade(true)
-                        .diskCacheKey(image?.name)
-                        .build(),
-                    contentScale = ContentScale.Crop,
-                    contentDescription = title,
-                )
-            }
+            FeedingPointImage(
+                image = image,
+                contentDescription = title
+            )
             Column(
                 modifier = Modifier
                     .weight(1f)

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/FeedingPointSheet.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/FeedingPointSheet.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentAlpha
@@ -28,7 +27,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -38,8 +36,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import com.epmedu.animeal.extensions.formatNumberToHourMin
 import com.epmedu.animeal.feeding.domain.model.enum.Remoteness
 import com.epmedu.animeal.feeding.presentation.model.FeedStatus
@@ -129,22 +125,10 @@ internal fun FeedingPointHeader(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Card(
-            modifier = Modifier
-                .size(80.dp)
-                .clip(RoundedCornerShape(16.dp)),
-            elevation = 8.dp
-        ) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(image?.url)
-                    .crossfade(true)
-                    .diskCacheKey(image?.name)
-                    .build(),
-                contentScale = ContentScale.Crop,
-                contentDescription = title,
-            )
-        }
+        FeedingPointImage(
+            image = image,
+            contentDescription = title
+        )
         Column(
             modifier = Modifier
                 .fillMaxHeight()

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/MarkFeedingDoneSheet.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/ui/MarkFeedingDoneSheet.kt
@@ -2,14 +2,12 @@ package com.epmedu.animeal.feeding.presentation.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
@@ -29,11 +27,13 @@ import com.epmedu.animeal.feeding.presentation.model.FeedingPhotoItem
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
 import com.epmedu.animeal.foundation.theme.CustomColor
+import com.epmedu.animeal.networkstorage.domain.NetworkFile
 import com.epmedu.animeal.resources.R
 
 @Composable
 fun MarkFeedingDoneSheet(
-    feedingPointTitle: String,
+    title: String,
+    image: NetworkFile?,
     onTakePhotoClick: () -> Unit,
     onDeletePhotoClick: (FeedingPhotoItem) -> Unit,
     modifier: Modifier = Modifier,
@@ -61,7 +61,8 @@ fun MarkFeedingDoneSheet(
         )
 
         MarkFeedingDoneHeader(
-            title = feedingPointTitle
+            title = title,
+            image = image
         )
 
         Divider(
@@ -80,7 +81,8 @@ fun MarkFeedingDoneSheet(
 
 @Composable
 private fun MarkFeedingDoneHeader(
-    title: String
+    title: String,
+    image: NetworkFile?
 ) {
     Row(
         modifier = Modifier
@@ -89,11 +91,10 @@ private fun MarkFeedingDoneHeader(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .size(60.dp)
-                .clip(RoundedCornerShape(16.dp))
-                .background(MaterialTheme.colors.secondaryVariant)
+        FeedingPointImage(
+            size = 60.dp,
+            image = image,
+            contentDescription = title
         )
         Text(
             modifier = Modifier.weight(1f),
@@ -141,7 +142,8 @@ private fun MarkFeedingDoneSheetPreview(@PreviewParameter(LoremIpsum::class) tex
     AnimealTheme {
         MarkFeedingDoneSheet(
             modifier = Modifier.fillMaxHeight(),
-            feedingPointTitle = text.take(50),
+            title = text.take(50),
+            image = null,
             onDeletePhotoClick = {},
             onTakePhotoClick = {}
         )

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItem.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.epmedu.animeal.common.constants.DefaultConstants.EMPTY_STRING
+import com.epmedu.animeal.feeding.presentation.ui.FeedingPointImage
 import com.epmedu.animeal.feedings.presentation.model.FeedingModel
 import com.epmedu.animeal.feedings.presentation.model.FeedingModelStatus
 import com.epmedu.animeal.foundation.preview.AnimealPreview
@@ -40,7 +41,10 @@ fun FeedingItem(feedingModel: FeedingModel) {
                 .padding(12.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            FeedingItemImage(feedingModel.image)
+            FeedingPointImage(
+                image = feedingModel.image,
+                contentDescription = feedingModel.title
+            )
             FeedingItemDetails(feedingModel)
         }
     }


### PR DESCRIPTION
[Jira issue](https://jira.epam.com/jira/browse/EPMEDU-3293)

#### Description
  - Added missing implementation
  - Created `FeedingPointImage` composable to reuse across different screens and components

#### Screenshot
<details>
<summary>Screenshot</summary>

![Screenshot_20240217-161813_Animeal Dev.jpg](https://github.com/AnimealProject/animeal_android/assets/83027107/60205612-e770-4c4e-8faa-34697bd91840)
</details>

