### PR TITLE
[EPMEDU-3523]: Feeding time is displayed incorrectly if previous feeding was created from search and cancelled

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/di/HomeDomainModule.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/di/HomeDomainModule.kt
@@ -11,6 +11,7 @@ import com.epmedu.animeal.feeding.domain.usecase.RejectFeedingUseCase
 import com.epmedu.animeal.feeding.domain.usecase.StartFeedingUseCase
 import com.epmedu.animeal.feeding.domain.usecase.UpdateAnimalTypeSettingsUseCase
 import com.epmedu.animeal.home.domain.usecases.AnimalTypeUseCase
+import com.epmedu.animeal.timer.domain.usecase.GetTimerStateUseCase
 import com.epmedu.animeal.timer.domain.usecase.StartTimerUseCase
 import dagger.Module
 import dagger.Provides
@@ -32,9 +33,11 @@ object HomeDomainModule {
     @ViewModelScoped
     @Provides
     fun providesFetchCurrentFeedingUseCase(
+        getTimerStateUseCase: GetTimerStateUseCase,
         startTimerUseCase: StartTimerUseCase,
         feedingRepository: FeedingRepository
     ): FetchCurrentFeedingPointUseCase = FetchCurrentFeedingPointUseCase(
+        getTimerStateUseCase,
         startTimerUseCase,
         feedingRepository
     )

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
@@ -104,21 +104,9 @@ internal fun HomeScreenUI(
     }
 
     LaunchedEffect(key1 = state.timerState) {
-        when (state.timerState) {
-            is TimerState.Active -> {
-                onRouteEvent(
-                    RouteEvent.FeedingTimerUpdateRequest(
-                        state.timerState.timeLeft
-                    )
-                )
-            }
-
-            TimerState.Expired -> {
-                hideBottomSheet()
-                onFeedingEvent(FeedingEvent.Expired)
-            }
-
-            else -> {}
+        if (state.timerState == TimerState.Expired) {
+            hideBottomSheet()
+            onFeedingEvent(FeedingEvent.Expired)
         }
     }
 

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/HomeMapbox.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/HomeMapbox.kt
@@ -39,6 +39,7 @@ import com.epmedu.animeal.permissions.presentation.PermissionStatus
 import com.epmedu.animeal.resources.R
 import com.epmedu.animeal.router.model.RouteResult
 import com.epmedu.animeal.router.presentation.FeedingRouteState
+import com.epmedu.animeal.timer.data.model.TimerState
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapView
@@ -77,8 +78,23 @@ internal fun HomeMapbox(
             onMapClick = onMapClick
         )
 
-        when (val feedingRouteState = state.feedingRouteState) {
-            is FeedingRouteState.Disabled -> {
+        when {
+            state.feedingRouteState is FeedingRouteState.Active && state.timerState is TimerState.Active -> {
+                RouteTopBar(
+                    modifier = Modifier
+                        .statusBarsPadding()
+                        .padding(top = 16.dp)
+                        .padding(horizontal = 20.dp),
+                    timeLeft = context.formatNumberToHourMin(state.timerState.timeLeft)
+                        ?: stringResource(R.string.calculating_route),
+                    distanceLeft = state.feedingRouteState.distanceLeft?.run {
+                        " • ${context.formatMetersToKilometers(this)}"
+                    } ?: "",
+                    onCancelClick = onCancelRouteClick
+                )
+            }
+
+            else -> {
                 AnimealSwitch(
                     modifier = Modifier
                         .statusBarsPadding()
@@ -86,23 +102,6 @@ internal fun HomeMapbox(
                         .padding(top = 24.dp),
                     onSelectTab = onSelectTab,
                     defaultAnimalType = state.feedingPointState.defaultAnimalType
-                )
-            }
-
-            is FeedingRouteState.Active -> {
-                RouteTopBar(
-                    modifier = Modifier
-                        .statusBarsPadding()
-                        .padding(top = 16.dp)
-                        .padding(horizontal = 20.dp),
-                    timeLeft = context.formatNumberToHourMin(
-                        feedingRouteState.timeLeft
-                    )
-                        ?: stringResource(R.string.calculating_route),
-                    distanceLeft = feedingRouteState.distanceLeft?.run {
-                        " • ${context.formatMetersToKilometers(this)}"
-                    } ?: "",
-                    onCancelClick = onCancelRouteClick
                 )
             }
         }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
@@ -12,7 +12,6 @@ import com.epmedu.animeal.home.presentation.viewmodel.HomeState
 import com.epmedu.animeal.resources.R
 import com.epmedu.animeal.router.model.RouteResult
 import com.epmedu.animeal.router.presentation.FeedingRouteState
-import com.epmedu.animeal.timer.data.model.TimerState
 import com.mapbox.maps.MapView
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants.LOCATION_INDICATOR_LAYER
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -63,8 +62,7 @@ internal fun RouteView(
                 feedingRouteState is FeedingRouteState.Disabled -> {
                     mapView.removeRoute(mapBoxRouteInitOptions)
                 }
-                feedingRouteState is FeedingRouteState.Active &&
-                    timerState is TimerState.Active -> {
+                feedingRouteState is FeedingRouteState.Active -> {
                     if (feedingRouteState.routeData != null) {
                         feedingRouteState.routeData?.let { data ->
                             drawRoute(data, mapView, mapBoxRouteInitOptions)

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/FetchCurrentFeedingPointUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/FetchCurrentFeedingPointUseCase.kt
@@ -5,9 +5,12 @@ import com.epmedu.animeal.extensions.MINUTE_IN_MILLIS
 import com.epmedu.animeal.feeding.domain.model.FeedingPoint
 import com.epmedu.animeal.feeding.domain.model.UserFeeding
 import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
+import com.epmedu.animeal.timer.data.model.TimerState
+import com.epmedu.animeal.timer.domain.usecase.GetTimerStateUseCase
 import com.epmedu.animeal.timer.domain.usecase.StartTimerUseCase
 
 class FetchCurrentFeedingPointUseCase(
+    private val getTimerStateUseCase: GetTimerStateUseCase,
     private val startTimerUseCase: StartTimerUseCase,
     private val repository: FeedingRepository
 ) {
@@ -26,12 +29,18 @@ class FetchCurrentFeedingPointUseCase(
 
         return when {
             millisPassed < HOUR_IN_MILLIS -> {
-                startTimerUseCase(HOUR_IN_MILLIS - millisPassed, MINUTE_IN_MILLIS)
+                startTimer(millisPassed)
                 latestFeeding.feedingPoint
             }
             else -> {
                 null
             }
+        }
+    }
+
+    private fun startTimer(millisPassed: Long) {
+        if (getTimerStateUseCase().value !is TimerState.Active) {
+            startTimerUseCase(HOUR_IN_MILLIS - millisPassed, MINUTE_IN_MILLIS)
         }
     }
 }

--- a/shared/feature/router/src/main/java/com/epmedu/animeal/router/presentation/DefaultRouteHandler.kt
+++ b/shared/feature/router/src/main/java/com/epmedu/animeal/router/presentation/DefaultRouteHandler.kt
@@ -17,7 +17,6 @@ class DefaultRouteHandler(
     override fun handleRouteEvent(event: RouteEvent) {
         when (event) {
             is RouteEvent.FeedingRouteUpdateRequest -> updateRoute(event)
-            is RouteEvent.FeedingTimerUpdateRequest -> updateTimer(event)
         }
     }
 
@@ -37,25 +36,11 @@ class DefaultRouteHandler(
             updateState {
                 FeedingRouteState.Active(
                     showFullRoad = showFullRoad,
-                    event.result.distanceLeft,
-                    state.timeLeft,
-                    event.result.routeData
+                    distanceLeft = event.result.distanceLeft,
+                    routeData = event.result.routeData
                 )
             }
             showFullRoad = false
-        }
-    }
-
-    private fun updateTimer(event: RouteEvent.FeedingTimerUpdateRequest) {
-        if (state is FeedingRouteState.Active) {
-            updateState {
-                FeedingRouteState.Active(
-                    showFullRoad = showFullRoad,
-                    state.distanceLeft,
-                    event.timeLeft,
-                    state.routeData
-                )
-            }
         }
     }
 }

--- a/shared/feature/router/src/main/java/com/epmedu/animeal/router/presentation/FeedingRouteState.kt
+++ b/shared/feature/router/src/main/java/com/epmedu/animeal/router/presentation/FeedingRouteState.kt
@@ -9,7 +9,6 @@ sealed interface FeedingRouteState {
     data class Active(
         val showFullRoad: Boolean = false,
         val distanceLeft: Long? = null,
-        val timeLeft: Long? = null,
         val routeData: NavigationRoute? = null,
         val isError: Boolean = false
     ) : FeedingRouteState

--- a/shared/feature/router/src/main/java/com/epmedu/animeal/router/presentation/RouteEvent.kt
+++ b/shared/feature/router/src/main/java/com/epmedu/animeal/router/presentation/RouteEvent.kt
@@ -4,5 +4,4 @@ import com.epmedu.animeal.router.model.RouteResult
 
 sealed interface RouteEvent {
     data class FeedingRouteUpdateRequest(val result: RouteResult) : RouteEvent
-    data class FeedingTimerUpdateRequest(val timeLeft: Long) : RouteEvent
 }


### PR DESCRIPTION
[Jira issue](https://jira.epam.com/jira/browse/EPMEDU-3523)

#### Description
  - Added a check to prevent starting timer if it is already started
  - Refactored UI to rely on timer state for showing time left instead of route state
  
#### Video
| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/472a186a-882a-444e-9793-610276e695a6"> | <video src="https://github.com/AnimealProject/animeal_android/assets/83027107/894d6a4c-d7b5-4557-b702-53b74b03e414"> |