### PR TITLE
[EPMEDU-3540]: Hide feeding approval flow on prod

### DIFF
--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsPresentationModule.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsPresentationModule.kt
@@ -1,5 +1,6 @@
 package com.epmedu.animeal.feedings.di
 
+import com.epmedu.animeal.common.component.BuildConfigProvider
 import com.epmedu.animeal.feedings.domain.usecase.GetIsNewFeedingPendingUseCase
 import com.epmedu.animeal.feedings.presentation.viewmodel.handlers.FeedingsButtonHandler
 import com.epmedu.animeal.feedings.presentation.viewmodel.handlers.FeedingsButtonHandlerImpl
@@ -17,9 +18,11 @@ object FeedingsPresentationModule {
     @ViewModelScoped
     @Provides
     fun providesFeedingsButtonHandler(
+        buildConfigProvider: BuildConfigProvider,
         getCurrentUserGroupUseCase: GetCurrentUserGroupUseCase,
         getIsNewFeedingPendingUseCase: GetIsNewFeedingPendingUseCase
     ): FeedingsButtonHandler = FeedingsButtonHandlerImpl(
+        buildConfigProvider,
         getCurrentUserGroupUseCase,
         getIsNewFeedingPendingUseCase
     )


### PR DESCRIPTION
[Ticket ref](https://jira.epam.com/jira/browse/EPMEDU-3540)
Hid buttons that lead to the approval flow.

P. S. This should be reverted as soon as the approval flow is ready ([ticket](https://jira.epam.com/jira/browse/EPMEDU-3539)).