### PR TITLE
[EPMEDU-3528]: Fix onboarding buttons alignment

### DIFF
--- a/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/OnboardingScreenUI.kt
+++ b/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/OnboardingScreenUI.kt
@@ -17,13 +17,17 @@ internal fun OnboardingScreenUI(
     onSignInFacebook: () -> Unit
 ) {
     Column {
-        OnBoarding()
         Spacer(modifier = Modifier.weight(1f))
+        OnBoarding()
+        Spacer(
+            modifier = Modifier.weight(if (state.isFacebookLoginAvailable) 5f else 4f)
+        )
         ButtonsBlock(
             isFacebookButtonAvailable = state.isFacebookLoginAvailable,
             onSignInMobile = onSignInMobile,
             onSignInFacebook = onSignInFacebook,
         )
+        Spacer(modifier = Modifier.weight(1f))
     }
 }
 

--- a/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/ui/ButtonsBlock.kt
+++ b/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/ui/ButtonsBlock.kt
@@ -2,7 +2,6 @@ package com.epmedu.animeal.signup.onboarding.presentation.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
@@ -27,12 +26,7 @@ internal fun ButtonsBlock(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(
-                when {
-                    isFacebookButtonAvailable -> PaddingValues(24.dp)
-                    else -> PaddingValues(horizontal = 24.dp, vertical = 56.dp)
-                }
-            ),
+            .padding(horizontal = 24.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/ui/OnBoarding.kt
+++ b/feature/signupflow/onboarding/src/main/java/com/epmedu/animeal/signup/onboarding/presentation/ui/OnBoarding.kt
@@ -24,7 +24,7 @@ import com.epmedu.animeal.resources.R
 @Composable
 internal fun OnBoarding() {
     Column(
-        modifier = Modifier.padding(56.dp),
+        modifier = Modifier.padding(horizontal = 56.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Image(


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3528

### Description
- Fixed onboarding buttons alignment for smaller screen sizes

### Screenshot/Video
<details>
  <summary>Click to open</summary>

| Case | Before | After |
| --- | ------------- | ------------- |
| Prod 16:9 | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/66aad762-dc85-47eb-a8e1-1e71a7bcd834"> | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/e6002593-fac7-40f8-8d00-ea9feaf621e6"> |
| Dev 16:9 | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/47f199f1-f8af-4da7-a2d1-b05c37065a42"> | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/59a00f98-e4e1-4a15-a8e7-b33861868699"> |
| Prod 19:9 | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/0b447f94-580b-486c-b1e8-e4b48a3790c5"> | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/8374d910-6d81-458e-9d3f-baec7c6f0a67"> |
| Dev 19:9 | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/33839a8c-990e-449a-b4c2-bc8545530412"> | <image src="https://github.com/AnimealProject/animeal_android/assets/83027107/6c09bcb0-13c5-436a-9c2a-0b7b681edf77"> |
</details>
