### PR TITLE
[EPMEDU-3560]: Implement disabled state for outlined buttons

### DIFF
--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/button/AnimealButton.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/button/AnimealButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -44,7 +45,7 @@ fun AnimealButton(
         onClick = onClick
     ) {
         AutoSizeText(
-            textStyle = TextStyle(letterSpacing = 1.sp),
+            textStyle = TextStyle(letterSpacing = 1.sp, fontWeight = FontWeight.Bold),
             text = text,
             textSize = 16.sp,
             maxLines = 1,

--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/button/AnimealSecondaryButton.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/button/AnimealSecondaryButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.epmedu.animeal.foundation.preview.AnimealPreview
@@ -47,6 +48,7 @@ fun AnimealSecondaryButton(
             text = text,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
+            fontWeight = FontWeight.Bold
         )
     }
 }

--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/button/AnimealSecondaryButtonOutlined.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/button/AnimealSecondaryButtonOutlined.kt
@@ -1,20 +1,25 @@
 package com.epmedu.animeal.foundation.button
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.epmedu.animeal.foundation.preview.AnimealPreview
 import com.epmedu.animeal.foundation.theme.AnimealTheme
+import com.epmedu.animeal.foundation.theme.DisabledButtonColor
 import com.epmedu.animeal.foundation.theme.DisabledButtonContentColor
 
 @Composable
@@ -23,39 +28,55 @@ fun AnimealSecondaryButtonOutlined(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-) = OutlinedButton(
-    modifier = modifier.heightIn(min = 60.dp).fillMaxWidth(),
-    border = BorderStroke(1.dp, MaterialTheme.colors.primary),
-    colors = ButtonDefaults.outlinedButtonColors(
-        disabledContentColor = DisabledButtonContentColor
-    ),
-    elevation = ButtonDefaults.elevation(
-        defaultElevation = 0.dp,
-        pressedElevation = 0.dp,
-        disabledElevation = 0.dp,
-        hoveredElevation = 0.dp,
-        focusedElevation = 0.dp,
-    ),
-    shape = MaterialTheme.shapes.large,
-    enabled = enabled,
-    onClick = onClick
 ) {
-    Text(
-        text = text,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        color = MaterialTheme.colors.primary,
-        style = TextStyle(letterSpacing = 1.sp)
-    )
+    val primaryColor = if (enabled) MaterialTheme.colors.primary else DisabledButtonColor
+    OutlinedButton(
+        modifier = modifier
+            .heightIn(min = 60.dp)
+            .fillMaxWidth(),
+        border = BorderStroke(
+            width = 1.dp,
+            color = primaryColor
+        ),
+        colors = ButtonDefaults.outlinedButtonColors(
+            disabledContentColor = DisabledButtonContentColor
+        ),
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp,
+            disabledElevation = 0.dp,
+            hoveredElevation = 0.dp,
+            focusedElevation = 0.dp,
+        ),
+        shape = MaterialTheme.shapes.large,
+        enabled = enabled,
+        onClick = onClick
+    ) {
+        Text(
+            text = text,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            color = primaryColor,
+            style = TextStyle(letterSpacing = 1.sp, fontWeight = FontWeight.Bold)
+        )
+    }
 }
 
 @AnimealPreview
 @Composable
 private fun AnimealSecondaryButtonPreview() {
     AnimealTheme {
-        AnimealSecondaryButtonOutlined(
-            text = "Button",
-            onClick = {},
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            AnimealSecondaryButtonOutlined(
+                text = "Button",
+                onClick = {},
+            )
+            Divider()
+            AnimealSecondaryButtonOutlined(
+                text = "Disabled button",
+                onClick = { },
+                enabled = false
+            )
+        }
     }
 }


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3560

### Description
  - Added disabled state for `AnimealSecondaryButtonOutlined`
  - Fixed font weight for all buttons

### Screenshot/Video
<details>
  <summary>Click to open</summary>

![image](https://github.com/AnimealProject/animeal_android/assets/83027107/9a0524b1-586f-4d18-9fb1-8ebed07e1a8a)
![image](https://github.com/AnimealProject/animeal_android/assets/83027107/1bf28322-1543-46fc-8767-d386489952cf)
</details>
