### PR TITLE
[EPMEDU-2672]: Pet toggle on the map isn't changed based on changes on the map after applying new category on Search tab

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/di/HomeDomainModule.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/di/HomeDomainModule.kt
@@ -7,6 +7,7 @@ import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import com.epmedu.animeal.feeding.domain.usecase.CancelFeedingUseCase
 import com.epmedu.animeal.feeding.domain.usecase.FetchCurrentFeedingPointUseCase
 import com.epmedu.animeal.feeding.domain.usecase.FinishFeedingUseCase
+import com.epmedu.animeal.feeding.domain.usecase.GetAnimalTypeFromSettingsUseCase
 import com.epmedu.animeal.feeding.domain.usecase.RejectFeedingUseCase
 import com.epmedu.animeal.feeding.domain.usecase.StartFeedingUseCase
 import com.epmedu.animeal.feeding.domain.usecase.UpdateAnimalTypeSettingsUseCase
@@ -69,9 +70,12 @@ object HomeDomainModule {
     @ViewModelScoped
     @Provides
     fun providesGetAnimalTypeSettingsUseCase(
-        repository: ApplicationSettingsRepository,
+        getAnimalTypeFromSettingsUseCase: GetAnimalTypeFromSettingsUseCase,
         forcedFeedingPoint: ForcedArgumentsUseCase
-    ): AnimalTypeUseCase = AnimalTypeUseCase(repository, forcedFeedingPoint)
+    ): AnimalTypeUseCase = AnimalTypeUseCase(
+        getAnimalTypeFromSettingsUseCase,
+        forcedFeedingPoint
+    )
 
     @ViewModelScoped
     @Provides

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/domain/usecases/AnimalTypeUseCase.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/domain/usecases/AnimalTypeUseCase.kt
@@ -1,23 +1,17 @@
 package com.epmedu.animeal.home.domain.usecases
 
 import com.epmedu.animeal.common.constants.Arguments.ANIMAL_TYPE
-import com.epmedu.animeal.common.domain.ApplicationSettingsRepository
 import com.epmedu.animeal.common.domain.usecase.ForcedArgumentsUseCase
+import com.epmedu.animeal.feeding.domain.usecase.GetAnimalTypeFromSettingsUseCase
 import com.epmedu.animeal.foundation.tabs.model.AnimalType
-import kotlinx.coroutines.flow.first
 
 class AnimalTypeUseCase(
-    private val repository: ApplicationSettingsRepository,
+    private val getAnimalTypeFromSettingsUseCase: GetAnimalTypeFromSettingsUseCase,
     private val forcedArgumentsProvider: ForcedArgumentsUseCase
 ) {
 
     suspend operator fun invoke(): AnimalType =
         forcedArgumentsProvider<String>(ANIMAL_TYPE, hashCode())
             ?.let(AnimalType::valueOf)
-            ?: getAnimalTypeFromSettings()
-
-    private suspend fun getAnimalTypeFromSettings(): AnimalType {
-        val type = repository.getAppSettings().first().animalType
-        return AnimalType.getByName(type)
-    }
+            ?: getAnimalTypeFromSettingsUseCase()
 }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -10,6 +10,7 @@ import com.epmedu.animeal.common.presentation.viewmodel.handler.error.ErrorHandl
 import com.epmedu.animeal.common.presentation.viewmodel.handler.loading.LoadingHandler
 import com.epmedu.animeal.feeding.presentation.event.FeedingEvent
 import com.epmedu.animeal.feeding.presentation.event.FeedingPointEvent
+import com.epmedu.animeal.feeding.presentation.event.FeedingPointEvent.AnimalTypeChange
 import com.epmedu.animeal.feeding.presentation.viewmodel.handler.feeding.FeedingHandler
 import com.epmedu.animeal.feeding.presentation.viewmodel.handler.feedingpoint.FeedingPointHandler
 import com.epmedu.animeal.feedings.presentation.viewmodel.handlers.FeedingsButtonHandler
@@ -101,7 +102,7 @@ internal class HomeViewModel @Inject constructor(
             is TimerCancellationEvent -> viewModelScope.handleTimerCancellationEvent(event)
             is ErrorShowed -> hideError()
             ScreenCreated -> onScreenCreated()
-            ScreenDisplayed -> loadingHandler.hideLoading()
+            ScreenDisplayed -> onScreenDisplayed()
             is CameraEvent -> viewModelScope.handleCameraEvent(event)
             HomeScreenEvent.InitialLocationWasDisplayed -> confirmInitialLocationWasDisplayed()
             is HomeScreenEvent.FeedingGalleryEvent -> viewModelScope.handleGalleryEvent(event)
@@ -112,6 +113,16 @@ internal class HomeViewModel @Inject constructor(
     private fun onScreenCreated() {
         handleForcedFeedingPoint()
         viewModelScope.launch { fetchCurrentFeeding() }
+    }
+
+    private fun onScreenDisplayed() {
+        loadingHandler.hideLoading()
+        viewModelScope.launch { showCurrentAnimalType() }
+    }
+
+    private suspend fun showCurrentAnimalType() {
+        val animalType = animalTypeUseCase()
+        handleFeedingPointEvent(AnimalTypeChange(animalType))
     }
 
     private fun finishFeedingProcess() {

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/SearchScreen.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/SearchScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.withCreated
 import com.epmedu.animeal.feeding.presentation.viewmodel.WillFeedViewModel
 import com.epmedu.animeal.foundation.bottomsheet.AnimealBottomSheetValue
 import com.epmedu.animeal.foundation.bottomsheet.rememberAnimealBottomSheetState
@@ -18,6 +20,7 @@ fun SearchScreen() {
     val searchViewModel: SearchViewModel = hiltViewModel()
     val willFeedViewModel: WillFeedViewModel = hiltViewModel()
     val searchState by searchViewModel.stateFlow.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     val bottomSheetState = rememberAnimealBottomSheetState(AnimealBottomSheetValue.Hidden)
 
@@ -32,5 +35,11 @@ fun SearchScreen() {
 
     if (searchState.showingFeedingPoint != null) {
         LaunchedEffect(Unit) { bottomSheetState.expand() }
+    }
+
+    LaunchedEffect(Unit) {
+        lifecycleOwner.withCreated {
+            searchViewModel.handleEvents(SearchScreenEvent.ScreenCreated)
+        }
     }
 }

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/SearchScreenEvent.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/SearchScreenEvent.kt
@@ -4,6 +4,7 @@ import com.epmedu.animeal.feeding.presentation.model.FeedingPointModel
 import com.epmedu.animeal.foundation.tabs.model.AnimalType
 
 sealed interface SearchScreenEvent {
+    object ScreenCreated : SearchScreenEvent
     data class FeedingPointSelected(val feedingPoint: FeedingPointModel) : SearchScreenEvent
     object FeedingPointHidden : SearchScreenEvent
 
@@ -13,4 +14,5 @@ sealed interface SearchScreenEvent {
     ) : SearchScreenEvent
 
     data class Search(val query: String, val animalType: AnimalType) : SearchScreenEvent
+    data class AnimalTypeChange(val animalType: AnimalType) : SearchScreenEvent
 }

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/AnimalTypeHorizontalPager.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/AnimalTypeHorizontalPager.kt
@@ -5,23 +5,28 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.epmedu.animeal.foundation.tabs.AnimealPagerTabRow
 import com.epmedu.animeal.foundation.tabs.model.AnimalType
-import com.google.accompanist.pager.ExperimentalPagerApi
+import com.epmedu.animeal.tabs.search.presentation.SearchScreenEvent
+import com.epmedu.animeal.tabs.search.presentation.SearchScreenEvent.AnimalTypeChange
+import com.epmedu.animeal.tabs.search.presentation.viewmodel.SearchState
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPagerApi::class)
 @Composable
 fun AnimalTypeHorizontalPager(
+    state: SearchState,
     tabRowHorizontalPadding: Dp = 0.dp,
     scope: CoroutineScope,
+    onEvent: (SearchScreenEvent) -> Unit,
     content: @Composable (animalType: AnimalType) -> Unit,
 ) {
     val pages = remember { AnimalType.values() }
@@ -49,5 +54,15 @@ fun AnimalTypeHorizontalPager(
                 }
             }
         )
+    }
+
+    LaunchedEffect(state.animalType) {
+        pagerState.animateScrollToPage(state.animalType.ordinal)
+    }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            onEvent(AnimalTypeChange(pages[page]))
+        }
     }
 }

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/SearchScreenUi.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/SearchScreenUi.kt
@@ -236,8 +236,10 @@ private fun ScreenContent(
             .padding(top = 16.dp),
     ) {
         AnimalTypeHorizontalPager(
+            state = state,
             tabRowHorizontalPadding = 30.dp,
-            scope = scope
+            scope = scope,
+            onEvent = onEvent
         ) { animalType ->
 
             SearchFeedingPointsUi(

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/viewmodel/SearchState.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/viewmodel/SearchState.kt
@@ -15,7 +15,8 @@ data class SearchState(
     val favourites: ImmutableList<FeedingPointModel> = persistentListOf(),
     val showingFeedingPoint: FeedingPointModel? = null,
     val feedState: FeedState = FeedState(),
-    val permissionsState: PermissionsState = PermissionsState()
+    val permissionsState: PermissionsState = PermissionsState(),
+    val animalType: AnimalType = AnimalType.Dogs
 ) {
     fun getQueryBy(animalType: AnimalType) = when (animalType) {
         AnimalType.Dogs -> dogsQuery

--- a/library/foundation/src/main/java/com/epmedu/animeal/foundation/tabs/AnimealSwitch.kt
+++ b/library/foundation/src/main/java/com/epmedu/animeal/foundation/tabs/AnimealSwitch.kt
@@ -29,7 +29,7 @@ fun AnimealSwitch(
     onSelectTab: (animalType: AnimalType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var currentAnimalType by remember { mutableStateOf(defaultAnimalType) }
+    var currentAnimalType by remember(defaultAnimalType) { mutableStateOf(defaultAnimalType) }
 
     TabRow(
         selectedTabIndex = currentAnimalType.ordinal,

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/di/FeedingDomainModule.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/di/FeedingDomainModule.kt
@@ -5,6 +5,7 @@ import com.epmedu.animeal.feeding.domain.repository.FeedingPointRepository
 import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import com.epmedu.animeal.feeding.domain.usecase.AddFeedingPointToFavouritesUseCase
 import com.epmedu.animeal.feeding.domain.usecase.GetAllFeedingPointsUseCase
+import com.epmedu.animeal.feeding.domain.usecase.GetAnimalTypeFromSettingsUseCase
 import com.epmedu.animeal.feeding.domain.usecase.GetApprovedFeedingHistoriesUseCase
 import com.epmedu.animeal.feeding.domain.usecase.GetFeedStateUseCase
 import com.epmedu.animeal.feeding.domain.usecase.GetFeedingInProgressUseCase
@@ -12,6 +13,7 @@ import com.epmedu.animeal.feeding.domain.usecase.GetFeedingPointByIdUseCase
 import com.epmedu.animeal.feeding.domain.usecase.GetFeedingPointByPriorityUseCase
 import com.epmedu.animeal.feeding.domain.usecase.RemoveFeedingPointFromFavouritesUseCase
 import com.epmedu.animeal.feeding.domain.usecase.UpdateFeedStateUseCase
+import com.epmedu.animeal.permissions.domain.GetAppSettingsUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -74,4 +76,10 @@ object FeedingDomainModule {
     fun providesDeleteFavouriteFeedingPointUseCase(
         repo: FavouriteRepository
     ) = RemoveFeedingPointFromFavouritesUseCase(repo)
+
+    @ViewModelScoped
+    @Provides
+    fun providesGetAnimalTypeFromSettingsUseCase(
+        getAppSettingsUseCase: GetAppSettingsUseCase
+    ) = GetAnimalTypeFromSettingsUseCase(getAppSettingsUseCase)
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/GetAnimalTypeFromSettingsUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/GetAnimalTypeFromSettingsUseCase.kt
@@ -1,0 +1,16 @@
+package com.epmedu.animeal.feeding.domain.usecase
+
+import com.epmedu.animeal.foundation.tabs.model.AnimalType
+import com.epmedu.animeal.permissions.domain.GetAppSettingsUseCase
+import kotlinx.coroutines.flow.first
+
+class GetAnimalTypeFromSettingsUseCase(
+    private val getAppSettingsUseCase: GetAppSettingsUseCase
+) {
+
+    suspend operator fun invoke(): AnimalType {
+        return getAppSettingsUseCase().first().let {
+            AnimalType.getByName(it.animalType)
+        }
+    }
+}


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-2672

### Description
- Sync toggle on Map screen with the tabs on Search screen

### Screenshot/Video
<details>
  <summary>Click to open</summary>
<video src="https://github.com/AnimealProject/animeal_android/assets/20266407/44f2d83d-3b17-4faf-a246-8f32a53cb9ae">
</details>
