### PR TITLE
[EPMEDU-1504, EPMEDU-1513]: Navigate to feeding from Home and More screens

### DIFF
--- a/app/src/main/java/com/epmedu/animeal/component/AppSettingsProviderImpl.kt
+++ b/app/src/main/java/com/epmedu/animeal/component/AppSettingsProviderImpl.kt
@@ -25,6 +25,7 @@ internal class AppSettingsProviderImpl(
                 updateIsGeolocationPermissionRationaleShown(isGeolocationPermissionRationaleShown)
                 updateInitialCameraPermission(isCameraPermissionRequested)
                 updateAnimalType(animalType)
+                updateViewedFeedingIds(viewedFeedingIds)
             }
         }
     }
@@ -33,6 +34,7 @@ internal class AppSettingsProviderImpl(
         isGeolocationPermissionRationaleShown = isGeolocationPermissionRationaleShown,
         isCameraPermissionRequested = initialCameraPermission,
         animalType = animalType,
+        viewedFeedingIds = viewedFeedingIds
     )
 }
 
@@ -40,17 +42,20 @@ private class AppSettingsUpdateScopeImpl(
     override var isGeolocationPermissionRationaleShown: Boolean,
     override var isCameraPermissionRequested: Boolean,
     override var animalType: String,
+    override var viewedFeedingIds: Set<String>
 ) : AppSettingsUpdateScope {
 
     constructor(settings: AppSettings) : this(
         settings.isGeolocationPermissionRationaleShown,
         settings.isCameraPermissionRequested,
-        settings.animalType
+        settings.animalType,
+        settings.viewedFeedingIds
     )
 
     fun toAppSettings() = AppSettings(
         isGeolocationPermissionRationaleShown = isGeolocationPermissionRationaleShown,
         isCameraPermissionRequested = isCameraPermissionRequested,
         animalType = animalType,
+        viewedFeedingIds = viewedFeedingIds
     )
 }

--- a/app/src/main/java/com/epmedu/animeal/component/DataStorePreferences.kt
+++ b/app/src/main/java/com/epmedu/animeal/component/DataStorePreferences.kt
@@ -4,6 +4,7 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.epmedu.animeal.common.constants.DefaultConstants
 
 private val ANIMAL_TYPE = stringPreferencesKey("AnimalType")
@@ -11,6 +12,7 @@ private val INITIAL_CAMERA_PERMISSION = booleanPreferencesKey("InitialCameraPerm
 private val IS_GEOLOCATION_PERMISSION_RATIONALE_SHOWN = booleanPreferencesKey(
     "is_geolocation_permission_rationale_shown"
 )
+private val VIEWED_FEEDING_IDS = stringSetPreferencesKey("viewed_feedings_ids")
 
 val Preferences.animalType: String
     get() = this[ANIMAL_TYPE] ?: DefaultConstants.EMPTY_STRING
@@ -20,6 +22,9 @@ val Preferences.initialCameraPermission: Boolean
 
 val Preferences.isGeolocationPermissionRationaleShown: Boolean
     get() = this[IS_GEOLOCATION_PERMISSION_RATIONALE_SHOWN] ?: false
+
+val Preferences.viewedFeedingIds: Set<String>
+    get() = this[VIEWED_FEEDING_IDS] ?: emptySet()
 
 fun MutablePreferences.updateAnimalType(value: String) {
     this[ANIMAL_TYPE] = value
@@ -31,4 +36,8 @@ fun MutablePreferences.updateInitialCameraPermission(value: Boolean) {
 
 fun MutablePreferences.updateIsGeolocationPermissionRationaleShown(value: Boolean) {
     this[IS_GEOLOCATION_PERMISSION_RATIONALE_SHOWN] = value
+}
+
+fun MutablePreferences.updateViewedFeedingIds(feedingIds: Set<String>) {
+    this[VIEWED_FEEDING_IDS] = feedingIds
 }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -81,7 +81,9 @@ internal class HomeViewModel @Inject constructor(
         viewModelScope.restoreSavedFeedingPoint()
         viewModelScope.launch { collectPermissionsState() }
         viewModelScope.launch {
-            feedingsButtonHandler.getFeedingsButtonState().collect { feedingsButtonState ->
+            feedingsButtonHandler.getFeedingsButtonState(
+                shouldFetchFeedings = true
+            ).collect { feedingsButtonState ->
                 updateState { copy(feedingsButtonState = feedingsButtonState) }
             }
         }

--- a/feature/tabsflow/moreflow/more/src/main/java/com/epmedu/animeal/tabs/more/presentation/viewmodel/MoreViewModel.kt
+++ b/feature/tabsflow/moreflow/more/src/main/java/com/epmedu/animeal/tabs/more/presentation/viewmodel/MoreViewModel.kt
@@ -28,7 +28,9 @@ internal class MoreViewModel @Inject constructor(
                 MoreOption.Donate,
             )
 
-            feedingsButtonHandler.getFeedingsButtonState().collect { buttonState ->
+            feedingsButtonHandler.getFeedingsButtonState(
+                shouldFetchFeedings = false
+            ).collect { buttonState ->
                 when (buttonState) {
                     FeedingsButtonState.Hidden -> {
                         options.removeIf { it is MoreOption.Feedings }

--- a/library/common/src/main/java/com/epmedu/animeal/common/component/AppSettingsProvider.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/component/AppSettingsProvider.kt
@@ -13,10 +13,12 @@ interface AppSettingsUpdateScope {
     var isGeolocationPermissionRationaleShown: Boolean
     var isCameraPermissionRequested: Boolean
     var animalType: String
+    var viewedFeedingIds: Set<String>
 }
 
 data class AppSettings(
     val isGeolocationPermissionRationaleShown: Boolean,
     val isCameraPermissionRequested: Boolean,
-    val animalType: String
+    val animalType: String,
+    val viewedFeedingIds: Set<String>
 )

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/DataToDomainFeedingMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/DataToDomainFeedingMapper.kt
@@ -22,7 +22,7 @@ internal suspend fun OnCreateFeedingExtSubscription.OnCreateFeedingExt.toFeeding
     feeder: User? = null
 ): Feeding {
     return Feeding(
-        id = id(),
+        id = id() + createdAt(), // id is not unique because it is equal to the feeding point id
         feeder = feeder,
         status = status().toDomain(),
         date = Temporal.DateTime(createdAt()).toDate(),
@@ -36,7 +36,7 @@ internal suspend fun OnUpdateFeedingExtSubscription.OnUpdateFeedingExt.toFeeding
     feeder: User? = null
 ): Feeding {
     return Feeding(
-        id = id(),
+        id = id() + createdAt(), // id is not unique because it is equal to the feeding point id
         feeder = feeder,
         status = status().toDomain(),
         date = Temporal.DateTime(createdAt()).toDate(),

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/SearchFeedingToFeedingMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/data/mapper/SearchFeedingToFeedingMapper.kt
@@ -9,7 +9,7 @@ internal suspend fun SearchFeedingsQuery.Item.toFeeding(
     feeder: User?,
     getImageFrom: suspend (fileName: String) -> NetworkFile
 ) = Feeding(
-    id = id(),
+    id = id() + createdAt(), // id is not unique because it is equal to the feeding point id
     feeder = feeder,
     status = status().toDomain(),
     date = Temporal.DateTime(createdAt()).toDate(),

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsDomainModule.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsDomainModule.kt
@@ -1,10 +1,13 @@
 package com.epmedu.animeal.feedings.di
 
+import com.epmedu.animeal.common.domain.ApplicationSettingsRepository
 import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import com.epmedu.animeal.feedings.domain.usecase.ApproveFeedingUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetAllFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetHasReviewedFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetIsNewFeedingPendingUseCase
+import com.epmedu.animeal.feedings.domain.usecase.GetViewedFeedingsUseCase
+import com.epmedu.animeal.feedings.domain.usecase.UpdateViewedFeedingsUseCase
 import com.epmedu.animeal.networkuser.domain.repository.NetworkRepository
 import com.epmedu.animeal.networkuser.domain.usecase.GetCurrentUserGroupUseCase
 import dagger.Module
@@ -19,7 +22,10 @@ object FeedingsDomainModule {
 
     @ViewModelScoped
     @Provides
-    fun providesGetIsNewFeedingPendingUseCase() = GetIsNewFeedingPendingUseCase()
+    fun providesGetIsNewFeedingPendingUseCase(
+        feedingRepository: FeedingRepository,
+        applicationSettingsRepository: ApplicationSettingsRepository
+    ) = GetIsNewFeedingPendingUseCase(feedingRepository, applicationSettingsRepository)
 
     @ViewModelScoped
     @Provides
@@ -40,4 +46,16 @@ object FeedingsDomainModule {
     fun provideApproveFeedingUseCase(
         feedingRepository: FeedingRepository
     ): ApproveFeedingUseCase = ApproveFeedingUseCase(feedingRepository)
+
+    @ViewModelScoped
+    @Provides
+    fun provideGetViewedFeedingsUseCase(
+        applicationSettingsRepository: ApplicationSettingsRepository
+    ) = GetViewedFeedingsUseCase(applicationSettingsRepository)
+
+    @ViewModelScoped
+    @Provides
+    fun provideUpdateViewedFeedingsUseCase(
+        applicationSettingsRepository: ApplicationSettingsRepository
+    ) = UpdateViewedFeedingsUseCase(applicationSettingsRepository)
 }

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsDomainModule.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsDomainModule.kt
@@ -4,8 +4,8 @@ import com.epmedu.animeal.common.domain.ApplicationSettingsRepository
 import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import com.epmedu.animeal.feedings.domain.usecase.ApproveFeedingUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetAllFeedingsUseCase
-import com.epmedu.animeal.feedings.domain.usecase.GetHasReviewedFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetHasNewPendingFeedingUseCase
+import com.epmedu.animeal.feedings.domain.usecase.GetHasReviewedFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetViewedFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.UpdateViewedFeedingsUseCase
 import com.epmedu.animeal.networkuser.domain.repository.NetworkRepository

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsDomainModule.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsDomainModule.kt
@@ -5,7 +5,7 @@ import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import com.epmedu.animeal.feedings.domain.usecase.ApproveFeedingUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetAllFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetHasReviewedFeedingsUseCase
-import com.epmedu.animeal.feedings.domain.usecase.GetIsNewFeedingPendingUseCase
+import com.epmedu.animeal.feedings.domain.usecase.GetHasNewPendingFeedingUseCase
 import com.epmedu.animeal.feedings.domain.usecase.GetViewedFeedingsUseCase
 import com.epmedu.animeal.feedings.domain.usecase.UpdateViewedFeedingsUseCase
 import com.epmedu.animeal.networkuser.domain.repository.NetworkRepository
@@ -22,10 +22,10 @@ object FeedingsDomainModule {
 
     @ViewModelScoped
     @Provides
-    fun providesGetIsNewFeedingPendingUseCase(
+    fun providesGetHasNewPendingFeedingUseCase(
         feedingRepository: FeedingRepository,
         applicationSettingsRepository: ApplicationSettingsRepository
-    ) = GetIsNewFeedingPendingUseCase(feedingRepository, applicationSettingsRepository)
+    ) = GetHasNewPendingFeedingUseCase(feedingRepository, applicationSettingsRepository)
 
     @ViewModelScoped
     @Provides

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsPresentationModule.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/di/FeedingsPresentationModule.kt
@@ -1,7 +1,7 @@
 package com.epmedu.animeal.feedings.di
 
 import com.epmedu.animeal.common.component.BuildConfigProvider
-import com.epmedu.animeal.feedings.domain.usecase.GetIsNewFeedingPendingUseCase
+import com.epmedu.animeal.feedings.domain.usecase.GetHasNewPendingFeedingUseCase
 import com.epmedu.animeal.feedings.presentation.viewmodel.handlers.FeedingsButtonHandler
 import com.epmedu.animeal.feedings.presentation.viewmodel.handlers.FeedingsButtonHandlerImpl
 import com.epmedu.animeal.networkuser.domain.usecase.GetCurrentUserGroupUseCase
@@ -20,10 +20,10 @@ object FeedingsPresentationModule {
     fun providesFeedingsButtonHandler(
         buildConfigProvider: BuildConfigProvider,
         getCurrentUserGroupUseCase: GetCurrentUserGroupUseCase,
-        getIsNewFeedingPendingUseCase: GetIsNewFeedingPendingUseCase
+        getHasNewPendingFeedingUseCase: GetHasNewPendingFeedingUseCase
     ): FeedingsButtonHandler = FeedingsButtonHandlerImpl(
         buildConfigProvider,
         getCurrentUserGroupUseCase,
-        getIsNewFeedingPendingUseCase
+        getHasNewPendingFeedingUseCase
     )
 }

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetAllFeedingsUseCase.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetAllFeedingsUseCase.kt
@@ -25,15 +25,11 @@ class GetAllFeedingsUseCase(
             if (userGroupResult is ActionResult.Success) {
                 when (userGroupResult.result) {
                     UserGroup.Administrator -> {
-                        repository.getAllFeedings(shouldFetch = true).map { feedings ->
-                            feedings.sortedBy { feeding -> feeding.date }
-                        }
+                        repository.getAllFeedings(shouldFetch = true).map(::sortByDate)
                     }
 
                     UserGroup.Moderator -> {
-                        repository.getAssignedFeedings().map { feedings ->
-                            feedings.sortedBy { feeding -> feeding.date }
-                        }
+                        repository.getAssignedFeedings().map(::sortByDate)
                     }
 
                     UserGroup.Volunteer -> {
@@ -44,5 +40,9 @@ class GetAllFeedingsUseCase(
                 flowOf(emptyList())
             }
         }
+    }
+
+    private fun sortByDate(feedings: List<Feeding>): List<Feeding> {
+        return feedings.sortedBy { feeding -> feeding.date }
     }
 }

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetAllFeedingsUseCase.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetAllFeedingsUseCase.kt
@@ -26,13 +26,13 @@ class GetAllFeedingsUseCase(
                 when (userGroupResult.result) {
                     UserGroup.Administrator -> {
                         repository.getAllFeedings(shouldFetch = true).map { feedings ->
-                            feedings.sortedByDescending { feeding -> feeding.date }
+                            feedings.sortedBy { feeding -> feeding.date }
                         }
                     }
 
                     UserGroup.Moderator -> {
                         repository.getAssignedFeedings().map { feedings ->
-                            feedings.sortedByDescending { feeding -> feeding.date }
+                            feedings.sortedBy { feeding -> feeding.date }
                         }
                     }
 

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetHasNewPendingFeedingUseCase.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetHasNewPendingFeedingUseCase.kt
@@ -6,7 +6,7 @@ import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 
-class GetIsNewFeedingPendingUseCase(
+class GetHasNewPendingFeedingUseCase(
     private val feedingRepository: FeedingRepository,
     private val applicationSettingsRepository: ApplicationSettingsRepository
 ) {

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetIsNewFeedingPendingUseCase.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetIsNewFeedingPendingUseCase.kt
@@ -1,12 +1,25 @@
 package com.epmedu.animeal.feedings.domain.usecase
 
+import com.epmedu.animeal.common.domain.ApplicationSettingsRepository
+import com.epmedu.animeal.feeding.domain.model.FeedingStatus
+import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.combine
 
-class GetIsNewFeedingPendingUseCase {
+class GetIsNewFeedingPendingUseCase(
+    private val feedingRepository: FeedingRepository,
+    private val applicationSettingsRepository: ApplicationSettingsRepository
+) {
 
-    operator fun invoke(): Flow<Boolean> {
-        // TODO: Replace with actual implementation
-        return flowOf(true)
+    operator fun invoke(shouldFetch: Boolean): Flow<Boolean> {
+        return combine(
+            applicationSettingsRepository.getAppSettings(),
+            feedingRepository.getAllFeedings(shouldFetch = shouldFetch)
+        ) { appSettings, feedings ->
+            feedings.any { feeding ->
+                feeding.status == FeedingStatus.Pending &&
+                    appSettings.viewedFeedingIds.contains(feeding.id).not()
+            }
+        }
     }
 }

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetViewedFeedingsUseCase.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/GetViewedFeedingsUseCase.kt
@@ -1,0 +1,16 @@
+package com.epmedu.animeal.feedings.domain.usecase
+
+import com.epmedu.animeal.common.domain.ApplicationSettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class GetViewedFeedingsUseCase(
+    private val applicationSettingsRepository: ApplicationSettingsRepository
+) {
+    operator fun invoke(): Flow<Set<String>> {
+        return applicationSettingsRepository.getAppSettings()
+            .map { appSettings ->
+                appSettings.viewedFeedingIds
+            }
+    }
+}

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/UpdateViewedFeedingsUseCase.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/domain/usecase/UpdateViewedFeedingsUseCase.kt
@@ -1,0 +1,14 @@
+package com.epmedu.animeal.feedings.domain.usecase
+
+import com.epmedu.animeal.common.domain.ApplicationSettingsRepository
+
+class UpdateViewedFeedingsUseCase(
+    private val applicationSettingsRepository: ApplicationSettingsRepository
+) {
+
+    suspend operator fun invoke(viewedFeedingId: String) {
+        applicationSettingsRepository.updateAppSettings {
+            viewedFeedingIds += viewedFeedingId
+        }
+    }
+}

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/viewmodel/handlers/FeedingsButtonHandler.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/viewmodel/handlers/FeedingsButtonHandler.kt
@@ -5,5 +5,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface FeedingsButtonHandler {
 
-    fun getFeedingsButtonState(): Flow<FeedingsButtonState>
+    fun getFeedingsButtonState(shouldFetchFeedings: Boolean): Flow<FeedingsButtonState>
 }

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/viewmodel/handlers/FeedingsButtonHandlerImpl.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/viewmodel/handlers/FeedingsButtonHandlerImpl.kt
@@ -2,7 +2,7 @@ package com.epmedu.animeal.feedings.presentation.viewmodel.handlers
 
 import com.epmedu.animeal.common.component.BuildConfigProvider
 import com.epmedu.animeal.common.domain.wrapper.ActionResult
-import com.epmedu.animeal.feedings.domain.usecase.GetIsNewFeedingPendingUseCase
+import com.epmedu.animeal.feedings.domain.usecase.GetHasNewPendingFeedingUseCase
 import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState
 import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState.Hidden
 import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState.Pulsating
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class FeedingsButtonHandlerImpl @Inject constructor(
     private val buildConfigProvider: BuildConfigProvider,
     private val getUserGroupUseCase: GetCurrentUserGroupUseCase,
-    private val getIsNewFeedingPendingUseCase: GetIsNewFeedingPendingUseCase
+    private val getHasNewPendingFeedingUseCase: GetHasNewPendingFeedingUseCase
 ) : FeedingsButtonHandler {
 
     override fun getFeedingsButtonState(shouldFetchFeedings: Boolean): Flow<FeedingsButtonState> {
@@ -30,11 +30,11 @@ class FeedingsButtonHandlerImpl @Inject constructor(
                 else -> {
                     emit(Static)
 
-                    getIsNewFeedingPendingUseCase(
+                    getHasNewPendingFeedingUseCase(
                         shouldFetchFeedings
-                    ).collect { isNewFeedingPending ->
+                    ).collect { hasNewPendingFeeding ->
                         emit(
-                            if (isNewFeedingPending) Pulsating else Static
+                            if (hasNewPendingFeeding) Pulsating else Static
                         )
                     }
                 }

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/viewmodel/handlers/FeedingsButtonHandlerImpl.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/viewmodel/handlers/FeedingsButtonHandlerImpl.kt
@@ -4,14 +4,13 @@ import com.epmedu.animeal.common.component.BuildConfigProvider
 import com.epmedu.animeal.common.domain.wrapper.ActionResult
 import com.epmedu.animeal.feedings.domain.usecase.GetIsNewFeedingPendingUseCase
 import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState
+import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState.Hidden
 import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState.Pulsating
 import com.epmedu.animeal.feedings.presentation.model.FeedingsButtonState.Static
 import com.epmedu.animeal.networkuser.domain.usecase.GetCurrentUserGroupUseCase
 import com.epmedu.animeal.users.domain.model.UserGroup
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import javax.inject.Inject
 
 class FeedingsButtonHandlerImpl @Inject constructor(
@@ -20,31 +19,30 @@ class FeedingsButtonHandlerImpl @Inject constructor(
     private val getIsNewFeedingPendingUseCase: GetIsNewFeedingPendingUseCase
 ) : FeedingsButtonHandler {
 
-    override fun getFeedingsButtonState(): Flow<FeedingsButtonState> {
-        return when {
-            buildConfigProvider.isProdFlavor -> {
-                flowOf(FeedingsButtonState.Hidden)
-            }
-            else -> {
-                combine(
-                    getIsNewFeedingPendingUseCase(),
-                    flow { emit(getUserGroupUseCase()) }
-                ) { isNewFeedingPending, userGroupResult ->
-                    when {
-                        userGroupResult.isEligibleForFeedingsButton() -> {
-                            if (isNewFeedingPending) Pulsating else Static
-                        }
+    override fun getFeedingsButtonState(shouldFetchFeedings: Boolean): Flow<FeedingsButtonState> {
+        return flow {
+            when {
+                buildConfigProvider.isProdFlavor ||
+                    getUserGroupUseCase().isEligibleForFeedingsButton().not() -> {
+                    emit(Hidden)
+                }
 
-                        else -> {
-                            FeedingsButtonState.Hidden
-                        }
+                else -> {
+                    emit(Static)
+
+                    getIsNewFeedingPendingUseCase(
+                        shouldFetchFeedings
+                    ).collect { isNewFeedingPending ->
+                        emit(
+                            if (isNewFeedingPending) Pulsating else Static
+                        )
                     }
                 }
             }
         }
     }
+}
 
-    private fun ActionResult<UserGroup>.isEligibleForFeedingsButton(): Boolean {
-        return this is ActionResult.Success && (result == UserGroup.Administrator || result == UserGroup.Moderator)
-    }
+private fun ActionResult<UserGroup>.isEligibleForFeedingsButton(): Boolean {
+    return this is ActionResult.Success && (result == UserGroup.Administrator || result == UserGroup.Moderator)
 }


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-1504
https://jira.epam.com/jira/browse/EPMEDU-1513

### Description
  - Implemented opening first not viewed feeding after navigating to the feedings screen
  - Implemented saving viewed feeding ids
  - Added `createdAt` value to feeding ids to make them unique
  - Added implementation for `GetIsNewFeedingPendingUseCase`
  - Refactored `FeedingsButtonHandler` to check for new pending feedings only after checking eligibility and show or hide button instantly
  - Fixed feeding sorting order

### Screenshot/Video
<details>
  <summary>Click to open</summary>

https://github.com/AnimealProject/animeal_android/assets/83027107/7168297a-9c99-40e9-9bf8-babc82bc1842
</details>
