### PR TITLE
Bump AGP version to 8.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ tasks {
     }
 
     registering(Delete::class) {
-        delete(buildDir)
+        delete(layout.buildDirectory)
     }
 }
 
@@ -81,10 +81,11 @@ subprojects {
         kotlinOptions {
             // https://issuetracker.google.com/issues/285090974
             val args = mutableListOf("-Xstring-concat=inline")
+            val buildDirectoryPath = project.layout.buildDirectory.get().asFile.absolutePath
 
             if (project.findProperty("animeal.enableComposeCompilerReports") == "true") {
-                args.add("-P=plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir.absolutePath}/compose_metrics")
-                args.add("-P=plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.buildDir.absolutePath}/compose_metrics")
+                args.add("-P=plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$buildDirectoryPath/compose_metrics")
+                args.add("-P=plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$buildDirectoryPath/compose_metrics")
             }
 
             freeCompilerArgs = freeCompilerArgs + args.toList()

--- a/buildSrc/src/main/java/com/epmedu/animeal/configure/BuildFeaturesConfigure.kt
+++ b/buildSrc/src/main/java/com/epmedu/animeal/configure/BuildFeaturesConfigure.kt
@@ -5,7 +5,7 @@ import com.epmedu.animeal.AnimealPluginExtension
 import com.epmedu.animeal.internal.libs
 import org.gradle.api.Project
 
-fun CommonExtension<*, *, *, *, *>.configureBuildFeatures(
+fun CommonExtension<*, *, *, *, *, *>.configureBuildFeatures(
     project: Project,
     pluginExtension: AnimealPluginExtension
 ) {

--- a/buildSrc/src/main/java/com/epmedu/animeal/configure/LibraryPluginSection.kt
+++ b/buildSrc/src/main/java/com/epmedu/animeal/configure/LibraryPluginSection.kt
@@ -24,7 +24,7 @@ internal fun Project.configureAndroidLibrary() = libraryExtension.run {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ compileSdk = "34"
 targetSdk = "34"
 minSdk = "26"
 
-androidGradlePlugin = "8.2.2"
+androidGradlePlugin = "8.5.0"
 
 accompanist = "0.30.1"
 activityCompose = "1.7.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 30 16:27:31 MSK 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description
- Bumped AGP version to 8.5.0
- Bumped Gradle version to 8.7
- Disabled minifying for library modules due to conflicts with Hilt
- Increased JVM memory
