### PR TITLE
[EPMEDU-3794]: No Show on map link when feeding is in progress

### DIFF
--- a/feature/tabsflow/favourites/src/main/java/com/epmedu/animeal/favourites/presentation/ui/FavouritesScreenUI.kt
+++ b/feature/tabsflow/favourites/src/main/java/com/epmedu/animeal/favourites/presentation/ui/FavouritesScreenUI.kt
@@ -142,6 +142,7 @@ private fun ScreenScaffold(
 ) {
     val scope = rememberCoroutineScope()
     val navigator = LocalNavigator.currentOrThrow
+    val feedingPointInProgress = state.feedState.feedPoint
 
     AnimealBottomSheetLayout(
         modifier = Modifier.statusBarsPadding(),
@@ -154,7 +155,8 @@ private fun ScreenScaffold(
                     feedingPoint = feedingPoint,
                     contentAlpha = contentAlpha,
                     modifier = Modifier.fillMaxHeight(),
-                    isShowOnMapVisible = state.feedState.feedPoint == null,
+                    isShowOnMapVisible = feedingPointInProgress == null ||
+                        feedingPointInProgress.id == feedingPoint.id,
                     onFavouriteChange = { isFavourite ->
                         onEvent(FavouriteChange(isFavourite, feedingPoint))
                     },
@@ -173,7 +175,7 @@ private fun ScreenScaffold(
             FeedingPointActionButton(
                 alpha = buttonAlpha,
                 enabled = state.showingFeedingPoint?.feedStatus == FeedStatus.Starved &&
-                    state.feedState.feedPoint == null,
+                    feedingPointInProgress == null,
                 onClick = { onWillFeedEvent(WillFeedClicked) },
             )
         }
@@ -213,6 +215,7 @@ private fun OnFeedingConfirmationState(
             navigator.navigateTo(TabsRoute.Home.name)
             onFeedingEvent(FeedingEvent.Reset)
         }
+
         FeedingWasAlreadyBooked -> {
             AnimealAlertDialog(
                 title = stringResource(id = R.string.feeding_point_expired_description),
@@ -222,6 +225,7 @@ private fun OnFeedingConfirmationState(
                 }
             )
         }
+
         else -> {}
     }
 }

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
@@ -121,6 +121,7 @@ internal fun HomeScreenUI(
         snapshotFlow { bottomSheetState.isHidden && state.feedingRouteState is Disabled }
             .distinctUntilChanged()
             .filter { it }
+            // skip first deselect to avoid race condition with initially selected feeding point
             .drop(1)
             .collect {
                 onFeedingPointEvent(Deselect)

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/viewmodel/HomeViewModel.kt
@@ -1,9 +1,7 @@
 package com.epmedu.animeal.home.presentation.viewmodel
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.epmedu.animeal.common.constants.Arguments.FORCED_FEEDING_POINT_ID
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.ActionDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.StateDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.handler.error.ErrorHandler
@@ -47,7 +45,6 @@ import javax.inject.Inject
 @HiltViewModel
 internal class HomeViewModel @Inject constructor(
     private val actionDelegate: ActionDelegate,
-    private val savedStateHandle: SavedStateHandle,
     private val gpsSettingsProvider: GpsSettingsProvider,
     private val locationProvider: LocationProvider,
     private val getTimerStateUseCase: GetTimerStateUseCase,
@@ -129,7 +126,7 @@ internal class HomeViewModel @Inject constructor(
 
     private fun finishFeedingProcess() {
         deselectFeedingPoint()
-        dismissThankYouDialog()
+        viewModelScope.launch { dismissThankYouDialog() }
         updateState { copy(feedingPhotos = emptyList()) }
     }
 
@@ -220,11 +217,9 @@ internal class HomeViewModel @Inject constructor(
 
     private fun handleForcedFeedingPoint() {
         viewModelScope.launch {
-            val forcedFeedingPointId: String? = savedStateHandle[FORCED_FEEDING_POINT_ID]
-            if (forcedFeedingPointId != null) {
+            getForcedFeedingPointId()?.let { id ->
                 nearestFeedingJob.cancel()
-                savedStateHandle[FORCED_FEEDING_POINT_ID] = null
-                showFeedingPoint(forcedFeedingPointId)?.coordinates?.let {
+                showFeedingPoint(id)?.coordinates?.let {
                     collectLocations(Location(it.latitude(), it.longitude()))
                 }
             }

--- a/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/SearchScreenUi.kt
+++ b/feature/tabsflow/search/src/main/java/com/epmedu/animeal/tabs/search/presentation/ui/SearchScreenUi.kt
@@ -191,12 +191,15 @@ private fun SearchSheetContent(
     contentAlpha: Float,
     onEvent: (SearchScreenEvent) -> Unit
 ) {
+    val feedingPointInProgress = state.feedState.feedPoint
+
     state.showingFeedingPoint?.let { feedingPoint ->
         FeedingPointSheetContent(
             feedingPoint = feedingPoint,
             contentAlpha = contentAlpha,
             modifier = Modifier.fillMaxHeight(),
-            isShowOnMapVisible = state.feedState.feedPoint == null,
+            isShowOnMapVisible = feedingPointInProgress == null ||
+                feedingPointInProgress.id == feedingPoint.id,
             onFavouriteChange = { isFavourite ->
                 onEvent(SearchScreenEvent.FavouriteChange(isFavourite, feedingPoint))
             },

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
@@ -7,7 +7,7 @@ interface ActionDelegate {
     suspend fun performAction(
         action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit = {},
-        onError: () -> Unit = {},
+        onError: suspend () -> Unit = {},
     )
 
     suspend fun <T> performAction(

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/DefaultActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/DefaultActionDelegate.kt
@@ -13,7 +13,7 @@ class DefaultActionDelegate(
     override suspend fun performAction(
         action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit,
-        onError: () -> Unit
+        onError: suspend () -> Unit
     ) {
         coroutineScope {
             when (val result = withContext(dispatchers.IO) { action() }) {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/GetFeedStateUseCase.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/domain/usecase/GetFeedStateUseCase.kt
@@ -1,9 +1,10 @@
 package com.epmedu.animeal.feeding.domain.usecase
 
 import com.epmedu.animeal.feeding.domain.repository.FeedingRepository
+import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
 
 class GetFeedStateUseCase @Inject constructor(private val feedingRepository: FeedingRepository) {
 
-    operator fun invoke() = feedingRepository.getFeedStateFlow()
+    operator fun invoke() = feedingRepository.getFeedStateFlow().distinctUntilChanged()
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/mapper/FeedStateMapper.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/mapper/FeedStateMapper.kt
@@ -29,6 +29,7 @@ internal fun FeedingPointModel.toDomainFeedingPoint(): FeedingPoint =
             else -> AnimalState.Starved
         },
         animalType = animalType,
+        isFavourite = isFavourite,
         image = image,
         location = MapLocation(
             latitude = coordinates.latitude(),

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
@@ -28,13 +28,12 @@ import com.epmedu.animeal.feeding.presentation.viewmodel.FeedingConfirmationStat
 import com.epmedu.animeal.feeding.presentation.viewmodel.FeedingConfirmationState.FeedingStarted
 import com.epmedu.animeal.feeding.presentation.viewmodel.FeedingConfirmationState.FeedingWasAlreadyBooked
 import com.epmedu.animeal.feeding.presentation.viewmodel.handler.feedingpoint.FeedingPointHandler
+import com.epmedu.animeal.router.presentation.FeedingRouteState
 import com.epmedu.animeal.router.presentation.RouteHandler
 import com.epmedu.animeal.timer.presentation.handler.TimerHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList")
@@ -69,27 +68,30 @@ class DefaultFeedingHandler(
         fetchCurrentFeedingJob?.cancel()
         fetchCurrentFeedingJob = launch {
             fetchCurrentFeedingPointUseCase()?.let { feedingPoint ->
-                updateFeedingState(
-                    feedingConfirmationState = Dismissed,
-                    feedPoint = FeedingPointModel(feedingPoint)
-                )
-                showSingleReservedFeedingPoint(FeedingPointModel(feedingPoint))
-                startRoute()
+                if (feedingRouteStateFlow.value is FeedingRouteState.Disabled) {
+                    updateFeedingState(
+                        feedingConfirmationState = Dismissed,
+                        feedPoint = FeedingPointModel(feedingPoint)
+                    )
+                    showSingleReservedFeedingPoint(FeedingPointModel(feedingPoint))
+                    startRoute()
+                }
             } ?: run {
                 updateFeedingState(
                     feedingConfirmationState = Dismissed
                 )
             }
         }
-        stateFlow.onEach {
-            // updates state flow at repository
-            updateFeedStateUseCase(it.toDomainFeedState())
-        }.launchIn(this)
         launch {
             getFeedStateUseCase().collect { feedState ->
+                if (feedingRouteStateFlow.value is FeedingRouteState.Disabled && feedState.feedPoint != null) {
+                    showSingleReservedFeedingPoint(FeedingPointModel(feedState.feedPoint))
+                    startRoute()
+                }
                 updateFeedingState(
                     feedingConfirmationState = feedState.feedingConfirmationState.toPresentationFeedingConfirmationState(),
                     feedPoint = feedState.feedPoint?.let { FeedingPointModel(it) },
+                    updateGlobally = false
                 )
             }
         }
@@ -101,13 +103,14 @@ class DefaultFeedingHandler(
             Cancel -> cancelFeeding()
             Expired -> expireFeeding()
             is Finish -> finishFeeding(event.feedingPhotos)
-            Reset -> restartFeedingConfirmationState()
+            Reset -> launch { restartFeedingConfirmationState() }
         }
     }
 
-    private fun restartFeedingConfirmationState() {
+    private suspend fun restartFeedingConfirmationState() {
         updateFeedingState(
-            feedingConfirmationState = Dismissed
+            feedingConfirmationState = Dismissed,
+            updateGlobally = false
         )
     }
 
@@ -188,18 +191,18 @@ class DefaultFeedingHandler(
         }
     }
 
-    private fun displayThankYouDialog() {
+    private suspend fun displayThankYouDialog() {
         updateFeedingState(FeedingConfirmationState.Showing)
     }
 
-    override fun dismissThankYouDialog() {
+    override suspend fun dismissThankYouDialog() {
         updateFeedingState(Dismissed)
     }
 
     private suspend fun performFeedingAction(
         action: suspend (String) -> ActionResult<Unit>,
         onSuccess: suspend (FeedingPointModel) -> Unit,
-        onError: () -> Unit = { showError() },
+        onError: suspend () -> Unit = { showError() },
     ) {
         state.feedPoint?.let { currentFeedingPoint ->
             performAction(
@@ -213,9 +216,10 @@ class DefaultFeedingHandler(
         }
     }
 
-    private fun updateFeedingState(
+    private suspend fun updateFeedingState(
         feedingConfirmationState: FeedingConfirmationState,
-        feedPoint: FeedingPointModel? = null
+        feedPoint: FeedingPointModel? = null,
+        updateGlobally: Boolean = true
     ) {
         updateState {
             copy(
@@ -223,6 +227,7 @@ class DefaultFeedingHandler(
                 feedingConfirmationState = feedingConfirmationState
             )
         }
+        if (updateGlobally) updateFeedStateUseCase(state.toDomainFeedState())
     }
 
     companion object {

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/FeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/FeedingHandler.kt
@@ -16,5 +16,6 @@ interface FeedingHandler {
     fun CoroutineScope.cancelFeeding()
 
     fun CoroutineScope.expireFeeding()
-    fun dismissThankYouDialog()
+
+    suspend fun dismissThankYouDialog()
 }

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/DefaultFeedingPointHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/DefaultFeedingPointHandler.kt
@@ -1,6 +1,7 @@
 package com.epmedu.animeal.feeding.presentation.viewmodel.handler.feedingpoint
 
 import androidx.lifecycle.SavedStateHandle
+import com.epmedu.animeal.common.constants.Arguments.FORCED_FEEDING_POINT_ID
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.ActionDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.delegate.StateDelegate
 import com.epmedu.animeal.common.presentation.viewmodel.handler.error.ErrorHandler
@@ -67,6 +68,10 @@ class DefaultFeedingPointHandler @Inject constructor(
     override fun CoroutineScope.restoreSavedFeedingPoint() {
         val savedFeedingPoint: FeedingPointModel? = savedStateHandle[SAVED_FEEDING_POINT_KEY]
         savedFeedingPoint?.let { selectFeedingPoint(savedFeedingPoint) }
+    }
+
+    override fun getForcedFeedingPointId(): String? {
+        return savedStateHandle[FORCED_FEEDING_POINT_ID]
     }
 
     override fun updateAnimalType(animalType: AnimalType) {
@@ -151,10 +156,16 @@ class DefaultFeedingPointHandler @Inject constructor(
 
     override suspend fun showSingleReservedFeedingPoint(feedingPoint: FeedingPointModel) {
         val reservedFeedingPoint = feedingPoint.copy(feedStatus = FeedStatus.InProgress)
+        val currentFeedingPoint = getForcedFeedingPointId()?.let { id ->
+            getFeedingPointByIdUseCase(id)?.let { point ->
+                FeedingPointModel(point)
+            }
+        }
+
         updateState {
             copy(
                 defaultAnimalType = reservedFeedingPoint.animalType,
-                currentFeedingPoint = null,
+                currentFeedingPoint = currentFeedingPoint,
                 feedingPoints = persistentListOf(reservedFeedingPoint)
             )
         }
@@ -177,6 +188,7 @@ class DefaultFeedingPointHandler @Inject constructor(
                     currentFeedingPoint = null,
                 )
             }
+            savedStateHandle[FORCED_FEEDING_POINT_ID] = null
         }
     }
 

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/FeedingPointHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feedingpoint/FeedingPointHandler.kt
@@ -8,6 +8,7 @@ import com.epmedu.animeal.foundation.tabs.model.AnimalType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
+@Suppress("ComplexInterface")
 interface FeedingPointHandler {
 
     var feedingPointStateFlow: StateFlow<FeedingPointState>
@@ -15,6 +16,8 @@ interface FeedingPointHandler {
     fun updateAnimalType(animalType: AnimalType)
 
     fun CoroutineScope.restoreSavedFeedingPoint()
+
+    fun getForcedFeedingPointId(): String?
 
     fun CoroutineScope.fetchFeedingPoints()
 


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3794

### Description
  - Enabled Show on map for feeding point in progress
  - Refactored feeding point forced by `Show on map` to show it during feeding flow
  - Refactored `FeedingHandler` to sync feed state between screens quicker
  - Refactored `LaunchedEffect` with the `Deselect` event to avoid deselecting on launch
  - Cherry-Pick to 1.0.14: https://github.com/AnimealProject/animeal_android/pull/321

### Screenshot/Video
<details>
  <summary>Click to open</summary>

https://github.com/AnimealProject/animeal_android/assets/83027107/91bdff17-8d66-46b4-ae3a-caadd5168356
</details>
