### PR TITLE
Fix Android Lint warnings

### DIFF
--- a/feature/tabsflow/home/src/main/AndroidManifest.xml
+++ b/feature/tabsflow/home/src/main/AndroidManifest.xml
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+</manifest>
 

--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/MapView.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/MapView.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.doOnDetach
 import com.epmedu.animeal.feeding.presentation.model.FeedingPointModel
 import com.epmedu.animeal.feeding.presentation.model.MapLocation
@@ -248,8 +249,8 @@ private fun MapView.requestRoutes(
 }
 
 private fun getLocationPuck(context: Context) = LocationPuck2D(
-    topImage = context.resources.getDrawable(R.drawable.ic_your_location, null),
-    shadowImage = context.resources.getDrawable(R.drawable.ic_map_user_stroke, null),
+    topImage = ResourcesCompat.getDrawable(context.resources, R.drawable.ic_your_location, null),
+    shadowImage = ResourcesCompat.getDrawable(context.resources, R.drawable.ic_map_user_stroke, null),
     scaleExpression = interpolate {
         linear()
         zoom()

--- a/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/GnssStatusCompat.kt
+++ b/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/GnssStatusCompat.kt
@@ -1,9 +1,11 @@
 package com.epmedu.animeal.geolocation.gpssetting
 
+import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.location.GnssStatus
 import android.location.LocationManager
 import android.os.Handler
 import android.os.Looper
+import androidx.annotation.RequiresPermission
 
 internal class GnssStatusCompat(
     private val locationManager: LocationManager,
@@ -12,6 +14,7 @@ internal class GnssStatusCompat(
 ) {
     private val statusListener = GnssStatusCallback(onGpsStarted, onGpsStopped)
 
+    @RequiresPermission(ACCESS_FINE_LOCATION)
     fun registerCallback() {
         locationManager.registerGnssStatusCallback(
             statusListener,

--- a/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/GpsSettingsProvider.kt
+++ b/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/GpsSettingsProvider.kt
@@ -1,5 +1,7 @@
 package com.epmedu.animeal.geolocation.gpssetting
 
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import androidx.annotation.RequiresPermission
 import kotlinx.coroutines.flow.Flow
 
 /** Provides info about GPS setting. */
@@ -7,5 +9,6 @@ interface GpsSettingsProvider {
 
     val gpsSettingState: GpsSettingState
 
+    @RequiresPermission(ACCESS_FINE_LOCATION)
     fun fetchGpsSettingsUpdates(): Flow<GpsSettingState>
 }

--- a/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/IntentGpsSettingsProvider.kt
+++ b/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/gpssetting/IntentGpsSettingsProvider.kt
@@ -1,6 +1,8 @@
 package com.epmedu.animeal.geolocation.gpssetting
 
+import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
+import androidx.annotation.RequiresPermission
 import androidx.core.location.LocationManagerCompat
 import com.epmedu.animeal.extensions.locationManager
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -20,6 +22,7 @@ internal class IntentGpsSettingsProvider(
             else -> GpsSettingState.Disabled
         }
 
+    @RequiresPermission(ACCESS_FINE_LOCATION)
     override fun fetchGpsSettingsUpdates() = callbackFlow {
         val gnssStatusCompat = GnssStatusCompat(
             locationManager = locationManager,

--- a/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/location/FusedLocationProviderImpl.kt
+++ b/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/location/FusedLocationProviderImpl.kt
@@ -1,7 +1,8 @@
 package com.epmedu.animeal.geolocation.location
 
-import android.annotation.SuppressLint
+import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.os.Looper
+import androidx.annotation.RequiresPermission
 import com.epmedu.animeal.geolocation.location.model.Location
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
@@ -13,15 +14,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import java.util.concurrent.TimeUnit
 
-@SuppressLint("MissingPermission")
 internal class FusedLocationProviderImpl(private val client: FusedLocationProviderClient) : LocationProvider {
 
+    @RequiresPermission(ACCESS_FINE_LOCATION)
     override fun fetchUpdates(): Flow<Location> = callbackFlow {
-        val locationRequest = LocationRequest.create().apply {
-            interval = TimeUnit.SECONDS.toMillis(UPDATE_INTERVAL_SECS)
-            fastestInterval = TimeUnit.SECONDS.toMillis(FASTEST_UPDATE_INTERVAL_SECS)
-            priority = Priority.PRIORITY_HIGH_ACCURACY
-        }
+        val locationRequest = LocationRequest.Builder(
+            TimeUnit.SECONDS.toMillis(UPDATE_INTERVAL_SECS)
+        )
+            .setPriority(Priority.PRIORITY_HIGH_ACCURACY)
+            .setMinUpdateIntervalMillis(TimeUnit.SECONDS.toMillis(FASTEST_UPDATE_INTERVAL_SECS))
+            .build()
 
         val callBack = object : LocationCallback() {
             override fun onLocationResult(locationResult: LocationResult) {

--- a/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/location/LocationProvider.kt
+++ b/library/geolocation/src/main/java/com/epmedu/animeal/geolocation/location/LocationProvider.kt
@@ -1,8 +1,12 @@
 package com.epmedu.animeal.geolocation.location
 
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import androidx.annotation.RequiresPermission
 import com.epmedu.animeal.geolocation.location.model.Location
 import kotlinx.coroutines.flow.Flow
 
 interface LocationProvider {
+
+    @RequiresPermission(ACCESS_FINE_LOCATION)
     fun fetchUpdates(): Flow<Location>
 }


### PR DESCRIPTION
### Description
  - Replaced Resources.getDrawable() with ResourcesCompat.getDrawable()
  - Added RequiresPermission annotation for methods requesting location
  - Refactored deprecated location request creation with builder
