### PR TITLE
[EPMEDU-3790]: After log out location of starting route to feeding point is changed

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/ui/map/RouteView.kt
@@ -132,17 +132,18 @@ private fun fetchRoute(
     mapboxNavigation: MapboxNavigation,
     onRouteResult: (result: RouteResult) -> Unit
 ) {
-    (state.locationState as? LocationState.ExactLocation)?.location?.toPoint()?.let { exactUserLocation ->
-        state.feedState.feedPoint?.coordinates?.let { feedingPointLocation ->
-            mapView.fetchRoute(
-                mapBoxRouteInitOptions = mapBoxRouteInitOptions,
-                navigation = mapboxNavigation,
-                path = MapPath(
-                    exactUserLocation,
-                    feedingPointLocation
-                ),
-                onRouteResult = onRouteResult
-            )
-        }
+    val exactUserLocation = (state.locationState as? LocationState.ExactLocation)?.location?.toPoint()
+    val feedingPointLocation = state.feedState.feedPoint?.coordinates
+
+    if (exactUserLocation != null && feedingPointLocation != null) {
+        mapView.fetchRoute(
+            mapBoxRouteInitOptions = mapBoxRouteInitOptions,
+            navigation = mapboxNavigation,
+            path = MapPath(
+                exactUserLocation,
+                feedingPointLocation
+            ),
+            onRouteResult = onRouteResult
+        )
     }
 }


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3790

### Description
  - Prevent route calculation if user's exact location is unknown
  - Force route recalculation when exact user location is acquired

### Screenshot/Video
<details>
  <summary>Click to open</summary>

https://github.com/user-attachments/assets/f1db06f3-5a89-457b-b173-94675da5635f


</details>
