### PR TITLE
[EPMEDU-3801]: Color of the feeding point remains yellow after process is finished

### DIFF
--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
@@ -8,6 +8,8 @@ interface ActionDelegate {
         action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit = {},
         onError: suspend () -> Unit = {},
+        onStart: suspend () -> Unit = {},
+        onFinish: suspend () -> Unit = {}
     )
 
     suspend fun <T> performAction(

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/DefaultActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/DefaultActionDelegate.kt
@@ -13,8 +13,11 @@ class DefaultActionDelegate(
     override suspend fun performAction(
         action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit,
-        onError: suspend () -> Unit
+        onError: suspend () -> Unit,
+        onStart: suspend () -> Unit,
+        onFinish: suspend () -> Unit
     ) {
+        onStart()
         coroutineScope {
             when (val result = withContext(dispatchers.IO) { action() }) {
                 is ActionResult.Success<*> -> {
@@ -26,6 +29,7 @@ class DefaultActionDelegate(
                 }
             }
         }
+        onFinish()
     }
 
     override suspend fun <T> performAction(

--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
@@ -155,15 +155,19 @@ class DefaultFeedingHandler(
     }
 
     override fun CoroutineScope.expireFeeding() {
-        /** stopRoute() is outside of onSuccess to immediately remove timer bar on TimerExpired Dialog */
-        stopRoute()
         launch {
             performFeedingAction(
+                onStart = {
+                    /** stopRoute() is outside of onSuccess to immediately remove timer bar on TimerExpired Dialog */
+                    stopRoute()
+                    deselectFeedingPoint()
+                },
                 action = { feedingPointId ->
                     rejectFeedingUseCase(feedingPointId, FEEDING_TIMER_EXPIRED)
                 },
-                onSuccess = {
-                    deselectFeedingPoint()
+                onFinish = {
+                    // if the feeding is expired by backend, rejectFeedingUseCase will return an error,
+                    // so we need to fetch feeding points no matter what the result is
                     fetchFeedingPoints()
                     updateFeedingState(Dismissed)
                 }
@@ -200,14 +204,18 @@ class DefaultFeedingHandler(
 
     private suspend fun performFeedingAction(
         action: suspend (String) -> ActionResult<Unit>,
-        onSuccess: suspend (FeedingPointModel) -> Unit,
+        onSuccess: suspend (FeedingPointModel) -> Unit = {},
         onError: suspend () -> Unit = { showError() },
+        onStart: suspend (String) -> Unit = {},
+        onFinish: suspend () -> Unit = {},
     ) {
         state.feedPoint?.let { currentFeedingPoint ->
             performAction(
                 action = { action(currentFeedingPoint.id) },
+                onStart = { onStart(currentFeedingPoint.id) },
                 onSuccess = { onSuccess(currentFeedingPoint) },
                 onError = onError,
+                onFinish = onFinish
             )
         } ?: run {
             onError()


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3801

### Description
- Refactored expire/reject feeding method to always fetch feeding points no matter what the result is
