### PR TITLE
🍒[EPMEDU-3801]: Color of the feeding point remains yellow after process is finished

### DIFF
--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/ActionDelegate.kt
@@ -8,6 +8,8 @@ interface ActionDelegate {
         action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit = {},
         onError: suspend () -> Unit = {},
+        onStart: suspend () -> Unit = {},
+        onFinish: suspend () -> Unit = {}
     )
 
     suspend fun <T> performAction(

--- a/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/DefaultActionDelegate.kt
+++ b/library/common/src/main/java/com/epmedu/animeal/common/presentation/viewmodel/delegate/DefaultActionDelegate.kt
@@ -13,8 +13,11 @@ class DefaultActionDelegate(
     override suspend fun performAction(
         action: suspend () -> ActionResult<Unit>,
         onSuccess: suspend () -> Unit,
-        onError: suspend () -> Unit
+        onError: suspend () -> Unit,
+        onStart: suspend () -> Unit,
+        onFinish: suspend () -> Unit
     ) {
+        onStart()
         coroutineScope {
             when (val result = withContext(dispatchers.IO) { action() }) {
                 is ActionResult.Success<*> -> {
@@ -26,6 +29,7 @@ class DefaultActionDelegate(
                 }
             }
         }
+        onFinish()
     }
 
     override suspend fun <T> performAction(


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3801

### Description
- Refactored expire/reject feeding method to always fetch feeding points no matter what the result is
- Cherry-picked from https://github.com/AnimealProject/animeal_android/pull/331
