### PR TITLE
Fix Android Lint warnings 2

### DIFF
--- a/app/src/dev/res/xml/network_security_config.xml
+++ b/app/src/dev/res/xml/network_security_config.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
 
     <base-config>
 
         <trust-anchors>
 
-            <certificates src="user" />
+            <certificates src="user"
+                tools:ignore="AcceptsUserCertificates" />
             <certificates src="system"/>
 
         </trust-anchors>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="true" />
+
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/qa/res/xml/network_security_config.xml
+++ b/app/src/qa/res/xml/network_security_config.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
 
     <base-config>
 
         <trust-anchors>
 
-            <certificates src="user" />
+            <certificates src="user"
+                tools:ignore="AcceptsUserCertificates" />
             <certificates src="system"/>
 
         </trust-anchors>

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItemSheetContent.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItemSheetContent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -35,7 +36,7 @@ internal fun FeedingItemSheetContent(
     contentAlpha: Float,
     modifier: Modifier = Modifier
 ) {
-    var currentPhotoIndex by rememberSaveable(feeding.id) { mutableStateOf(0) }
+    var currentPhotoIndex by rememberSaveable(feeding.id) { mutableIntStateOf(0) }
     val currentPhoto by remember(currentPhotoIndex, feeding.id) {
         mutableStateOf(feeding.photos[currentPhotoIndex])
     }


### PR DESCRIPTION
### Description
- Added missing `uses-feature` element to AndroidManifest.xml for camera
- Replaced `mutableStateOf` with `mutableIntStateOf`
- Ignored `AcceptsUserCertificates` warning for dev and qa builds