### PR TITLE
[EPMEDU-3811]: User is returned immediately on the map on clicking buttons Search or Favorites after feeding process is booked

### DIFF
--- a/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
+++ b/shared/feature/feeding/src/main/java/com/epmedu/animeal/feeding/presentation/viewmodel/handler/feeding/DefaultFeedingHandler.kt
@@ -131,7 +131,8 @@ class DefaultFeedingHandler(
                     startTimer()
                     updateFeedingState(
                         feedPoint = FeedingPointModel(feedingPoint),
-                        feedingConfirmationState = FeedingStarted
+                        feedingConfirmationState = FeedingStarted,
+                        updateGlobally = false
                     )
                 },
                 onError = {


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3811

### Description
  - Fixed by removing redundant update of global feeding confirmation state to navigate to Home only when feeding is started from other screens

### Screenshot/Video
<details>
  <summary>Click to open</summary>

https://github.com/user-attachments/assets/673daffc-2c35-483e-9f6d-c7659eb606b6
</details>
