### PR TITLE
fix: EPMEDU-3817: No padding between name and  time of feeding item

### DIFF
--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItem.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItem.kt
@@ -60,7 +60,7 @@ internal fun FeedingItem(
 @AnimealPreview
 @Composable
 fun FeedingItemPreview() {
-    val longText = "Very very very very very very very very very long text"
+    val longText = "1234567890123456789012345 25 symbols word"
     val shortText = "Short text"
     val image = NetworkFile(
         name = EMPTY_STRING,

--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItemDetails.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItemDetails.kt
@@ -31,7 +31,9 @@ internal fun FeedingItemDetails(feedingModel: FeedingModel) {
         ) {
             Text(
                 text = feedingModel.title,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 16.dp),
                 style = MaterialTheme.typography.subtitle1,
                 fontWeight = FontWeight.Bold,
                 overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3817

### Description
  - Add missing padding
