### PR TITLE
fix: EPMEDU-3851: Mapbox default elements are covered by app elements

### DIFF
--- a/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
+++ b/feature/tabsflow/home/src/main/java/com/epmedu/animeal/home/presentation/HomeScreenUI.kt
@@ -195,6 +195,7 @@ internal fun HomeScreenUI(
         ) { geolocationPermissionState ->
             HomeMapbox(
                 state = state,
+                bottomSheetState = bottomSheetState,
                 onFeedingPointSelect = { onFeedingPointEvent(FeedingPointEvent.Select(it)) },
                 onCameraChange = onCameraChange,
                 onMapClick = { hideBottomSheet() },


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-3851

### Description
  - Set bottom margin of logo and attribution dynamically depending on bottom sheet state to make them always visible on the map

### Screenshot/Video
<details>
  <summary>Click to open</summary>

https://github.com/user-attachments/assets/3d0fe995-7f8a-457a-867d-3142ae8b350c
</details>
