### PR TITLE
fix: EPMEDU-4090: Status not visible for names longer than 5 characters

### DIFF
--- a/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItemDetails.kt
+++ b/shared/feature/feedings/src/main/java/com/epmedu/animeal/feedings/presentation/ui/FeedingItemDetails.kt
@@ -38,7 +38,7 @@ internal fun FeedingItemDetails(feedingModel: FeedingModel) {
                 fontWeight = FontWeight.Bold,
                 overflow = TextOverflow.Ellipsis,
                 color = MaterialTheme.colors.onSurface,
-                maxLines = 2,
+                maxLines = 1,
             )
             Text(
                 text = feedingModel.elapsedTime,


### PR DESCRIPTION
### Ticket reference
https://jira.epam.com/jira/browse/EPMEDU-4090

### Description
  - Change maximum lines for feeding point name from 2 to 1 to fit other info in the feeding item on font scaling

### Screenshot/Video
<details>
  <summary>Click to open</summary>

![image](https://github.com/user-attachments/assets/ad853204-f900-4c16-88e7-8044c4f1e5a6)
</details>
